### PR TITLE
Auto refresh files and folders

### DIFF
--- a/Files UWP/AddItem.xaml.cs
+++ b/Files UWP/AddItem.xaml.cs
@@ -42,8 +42,8 @@ namespace Files
                 var userInput = GenericFileBrowser.inputForRename;
                 if (userInput != null)
                 {
-                    await folderToCreateItem.CreateFolderAsync(userInput, CreationCollisionOption.FailIfExists);
-                    App.ViewModel.FilesAndFolders.Add(new ListedItem(){ FileName = userInput, FileDate = "Now", EmptyImgVis = Visibility.Collapsed, FolderImg = Visibility.Visible, FileIconVis = Visibility.Collapsed, FileType = "Folder", FileImg = null, FilePath = (App.ViewModel.Universal.path + "\\" + userInput) });
+                    var folder = await folderToCreateItem.CreateFolderAsync(userInput, CreationCollisionOption.FailIfExists);
+                    App.ViewModel.AddFileOrFolder(new ListedItem(folder.FolderRelativeId){ FileName = userInput, FileDate = "Now", EmptyImgVis = Visibility.Collapsed, FolderImg = Visibility.Visible, FileIconVis = Visibility.Collapsed, FileType = "Folder", FileImg = null, FilePath = (App.ViewModel.Universal.path + "\\" + userInput) });
                 }
             }
             else if ((e.ClickedItem as AddListItem).Header == "Text Document")
@@ -52,8 +52,8 @@ namespace Files
                 var userInput = GenericFileBrowser.inputForRename;
                 if (userInput != null)
                 {
-                    await folderToCreateItem.CreateFileAsync(userInput + ".txt", CreationCollisionOption.FailIfExists);
-                    App.ViewModel.FilesAndFolders.Add(new ListedItem() { FileName = userInput, FileDate = "Now", EmptyImgVis = Visibility.Visible, FolderImg = Visibility.Collapsed, FileIconVis = Visibility.Collapsed, FileType = "Text Document", FileImg = null, FilePath = (App.ViewModel.Universal.path + "\\" + userInput + ".txt"), DotFileExtension = ".txt" });
+                    var folder = await folderToCreateItem.CreateFileAsync(userInput + ".txt", CreationCollisionOption.FailIfExists);
+                    App.ViewModel.AddFileOrFolder(new ListedItem(folder.FolderRelativeId) { FileName = userInput, FileDate = "Now", EmptyImgVis = Visibility.Visible, FolderImg = Visibility.Collapsed, FileIconVis = Visibility.Collapsed, FileType = "Text Document", FileImg = null, FilePath = (App.ViewModel.Universal.path + "\\" + userInput + ".txt"), DotFileExtension = ".txt" });
                 }
             }
             else if ((e.ClickedItem as AddListItem).Header == "Bitmap Image")
@@ -62,9 +62,8 @@ namespace Files
                 var userInput = GenericFileBrowser.inputForRename;
                 if (userInput != null)
                 {
-                    await folderToCreateItem.CreateFileAsync(userInput + ".bmp", CreationCollisionOption.FailIfExists);
-                    App.ViewModel.FilesAndFolders.Add(new ListedItem() { FileName = userInput, FileDate = "Now", EmptyImgVis = Visibility.Visible, FolderImg = Visibility.Collapsed, FileIconVis = Visibility.Collapsed, FileType = "BMP File", FileImg = null, FilePath = (App.ViewModel.Universal.path + "\\" + userInput + ".bmp"), DotFileExtension = ".bmp" });
-
+                    var folder = await folderToCreateItem.CreateFileAsync(userInput + ".bmp", CreationCollisionOption.FailIfExists);
+                    App.ViewModel.AddFileOrFolder(new ListedItem(folder.FolderRelativeId) { FileName = userInput, FileDate = "Now", EmptyImgVis = Visibility.Visible, FolderImg = Visibility.Collapsed, FileIconVis = Visibility.Collapsed, FileType = "BMP File", FileImg = null, FilePath = (App.ViewModel.Universal.path + "\\" + userInput + ".bmp"), DotFileExtension = ".bmp" });
                 }
             }
         }

--- a/Files UWP/AddItem.xaml.cs
+++ b/Files UWP/AddItem.xaml.cs
@@ -43,7 +43,7 @@ namespace Files
                 if (userInput != null)
                 {
                     var folder = await folderToCreateItem.CreateFolderAsync(userInput, CreationCollisionOption.FailIfExists);
-                    App.ViewModel.AddFileOrFolder(new ListedItem(folder.FolderRelativeId){ FileName = userInput, FileDate = "Now", EmptyImgVis = Visibility.Collapsed, FolderImg = Visibility.Visible, FileIconVis = Visibility.Collapsed, FileType = "Folder", FileImg = null, FilePath = (App.ViewModel.Universal.path + "\\" + userInput) });
+                    App.ViewModel.AddFileOrFolder(new ListedItem(folder.FolderRelativeId){ FileName = userInput, FileDateReal = DateTimeOffset.Now, EmptyImgVis = Visibility.Collapsed, FolderImg = Visibility.Visible, FileIconVis = Visibility.Collapsed, FileType = "Folder", FileImg = null, FilePath = (App.ViewModel.Universal.path + "\\" + userInput) });
                 }
             }
             else if ((e.ClickedItem as AddListItem).Header == "Text Document")
@@ -53,7 +53,7 @@ namespace Files
                 if (userInput != null)
                 {
                     var folder = await folderToCreateItem.CreateFileAsync(userInput + ".txt", CreationCollisionOption.FailIfExists);
-                    App.ViewModel.AddFileOrFolder(new ListedItem(folder.FolderRelativeId) { FileName = userInput, FileDate = "Now", EmptyImgVis = Visibility.Visible, FolderImg = Visibility.Collapsed, FileIconVis = Visibility.Collapsed, FileType = "Text Document", FileImg = null, FilePath = (App.ViewModel.Universal.path + "\\" + userInput + ".txt"), DotFileExtension = ".txt" });
+                    App.ViewModel.AddFileOrFolder(new ListedItem(folder.FolderRelativeId) { FileName = userInput, FileDateReal = DateTimeOffset.Now, EmptyImgVis = Visibility.Visible, FolderImg = Visibility.Collapsed, FileIconVis = Visibility.Collapsed, FileType = "Text Document", FileImg = null, FilePath = (App.ViewModel.Universal.path + "\\" + userInput + ".txt"), DotFileExtension = ".txt" });
                 }
             }
             else if ((e.ClickedItem as AddListItem).Header == "Bitmap Image")
@@ -63,7 +63,7 @@ namespace Files
                 if (userInput != null)
                 {
                     var folder = await folderToCreateItem.CreateFileAsync(userInput + ".bmp", CreationCollisionOption.FailIfExists);
-                    App.ViewModel.AddFileOrFolder(new ListedItem(folder.FolderRelativeId) { FileName = userInput, FileDate = "Now", EmptyImgVis = Visibility.Visible, FolderImg = Visibility.Collapsed, FileIconVis = Visibility.Collapsed, FileType = "BMP File", FileImg = null, FilePath = (App.ViewModel.Universal.path + "\\" + userInput + ".bmp"), DotFileExtension = ".bmp" });
+                    App.ViewModel.AddFileOrFolder(new ListedItem(folder.FolderRelativeId) { FileName = userInput, FileDateReal = DateTimeOffset.Now, EmptyImgVis = Visibility.Visible, FolderImg = Visibility.Collapsed, FileIconVis = Visibility.Collapsed, FileType = "BMP File", FileImg = null, FilePath = (App.ViewModel.Universal.path + "\\" + userInput + ".bmp"), DotFileExtension = ".bmp" });
                 }
             }
         }

--- a/Files UWP/Filesystem/ItemViewModel.cs
+++ b/Files UWP/Filesystem/ItemViewModel.cs
@@ -309,7 +309,7 @@ namespace Files.Filesystem
                 _classicFolderList.Add(new Classic_ListedFolderItem()
                 {
                     FileName = folder.Name,
-                    FileDate = ListedItem.GetFriendlyDate(basicProperties.DateModified.LocalDateTime),
+                    FileDate = ListedItem.GetFriendlyDate(basicProperties.DateModified),
                     FileExtension = "Folder",
                     FilePath = folder.Path
                 });

--- a/Files UWP/Filesystem/ListedItem.cs
+++ b/Files UWP/Filesystem/ListedItem.cs
@@ -24,7 +24,7 @@ namespace Files.Filesystem
             get { return _fileDataReal; }
             set
             {
-                FileDate = GetFriendlyDate(value.LocalDateTime);
+                FileDate = GetFriendlyDate(value);
                 _fileDataReal = value;
             }
         }
@@ -36,164 +36,29 @@ namespace Files.Filesystem
             FolderRelativeId = folderRelativeId;
         }
 
-        public static string GetFriendlyDate(DateTime d)
+        public static string GetFriendlyDate(DateTimeOffset d)
         {
-            if (d.Year == DateTime.Now.Year)              // If item is accessed in the same year as stored
-            {
-                if (d.Month == DateTime.Now.Month)        // If item is accessed in the same month as stored
-                {
-                    if ((DateTime.Now.Day - d.Day) < 7) // If item is accessed on the same week
-                    {
-                        if (d.DayOfWeek == DateTime.Now.DayOfWeek)   // If item is accessed on the same day as stored
-                        {
-                            if ((DateTime.Now.Hour - d.Hour) > 1)
-                            {
-                                return DateTime.Now.Hour - d.Hour + " hours ago";
-                            }
-                            else
-                            {
-                                return DateTime.Now.Minute - d.Minute + " hour ago";
-                            }
-                        }
-                        else                                                        // If item is from a previous day of the same week
-                        {
-                            return d.DayOfWeek + " at " + d.ToShortTimeString();
-                        }
-                    }
-                    else                                                          // If item is from a previous week of the same month
-                    {
-                        string monthAsString = "Month";
-                        switch (d.Month)
-                        {
-                            case 1:
-                                monthAsString = "January";
-                                break;
-                            case 2:
-                                monthAsString = "February";
-                                break;
-                            case 3:
-                                monthAsString = "March";
-                                break;
-                            case 4:
-                                monthAsString = "April";
-                                break;
-                            case 5:
-                                monthAsString = "May";
-                                break;
-                            case 6:
-                                monthAsString = "June";
-                                break;
-                            case 7:
-                                monthAsString = "July";
-                                break;
-                            case 8:
-                                monthAsString = "August";
-                                break;
-                            case 9:
-                                monthAsString = "September";
-                                break;
-                            case 10:
-                                monthAsString = "October";
-                                break;
-                            case 11:
-                                monthAsString = "November";
-                                break;
-                            case 12:
-                                monthAsString = "December";
-                                break;
-                        }
-                        return monthAsString + " " + d.Day;
-                    }
+            var elapsed = DateTimeOffset.Now - d;
 
-                }
-                else                                                            // If item is from a past month of the same year
-                {
-                    string monthAsString = "Month";
-                    switch (d.Month)
-                    {
-                        case 1:
-                            monthAsString = "January";
-                            break;
-                        case 2:
-                            monthAsString = "February";
-                            break;
-                        case 3:
-                            monthAsString = "March";
-                            break;
-                        case 4:
-                            monthAsString = "April";
-                            break;
-                        case 5:
-                            monthAsString = "May";
-                            break;
-                        case 6:
-                            monthAsString = "June";
-                            break;
-                        case 7:
-                            monthAsString = "July";
-                            break;
-                        case 8:
-                            monthAsString = "August";
-                            break;
-                        case 9:
-                            monthAsString = "September";
-                            break;
-                        case 10:
-                            monthAsString = "October";
-                            break;
-                        case 11:
-                            monthAsString = "November";
-                            break;
-                        case 12:
-                            monthAsString = "December";
-                            break;
-                    }
-                    return monthAsString + " " + d.Day;
-                }
-            }
-            else                                                                // If item is from a past year
+            if (elapsed.TotalDays > 7)
             {
-                string monthAsString = "Month";
-                switch (d.Month)
-                {
-                    case 1:
-                        monthAsString = "January";
-                        break;
-                    case 2:
-                        monthAsString = "February";
-                        break;
-                    case 3:
-                        monthAsString = "March";
-                        break;
-                    case 4:
-                        monthAsString = "April";
-                        break;
-                    case 5:
-                        monthAsString = "May";
-                        break;
-                    case 6:
-                        monthAsString = "June";
-                        break;
-                    case 7:
-                        monthAsString = "July";
-                        break;
-                    case 8:
-                        monthAsString = "August";
-                        break;
-                    case 9:
-                        monthAsString = "September";
-                        break;
-                    case 10:
-                        monthAsString = "October";
-                        break;
-                    case 11:
-                        monthAsString = "November";
-                        break;
-                    case 12:
-                        monthAsString = "December";
-                        break;
-                }
-                return monthAsString + " " + d.Day + ", " + d.Year;
+                return d.ToString("D");
+            }
+            else if (elapsed.TotalDays > 1)
+            {
+                return $"{elapsed.Days} days ago";
+            }
+            else if (elapsed.TotalHours > 1)
+            {
+                return $"{elapsed.Hours} hours ago";
+            }
+            else if (elapsed.TotalMinutes > 1)
+            {
+                return $"{elapsed.Minutes} minutes ago";
+            }
+            else
+            {
+                return $"{elapsed.Seconds} seconds ago";
             }
         }
     }

--- a/Files UWP/Filesystem/ListedItem.cs
+++ b/Files UWP/Filesystem/ListedItem.cs
@@ -1,4 +1,5 @@
-﻿using Windows.UI.Xaml;
+﻿using System;
+using Windows.UI.Xaml;
 using Windows.UI.Xaml.Media.Imaging;
 
 namespace Files.Filesystem
@@ -12,15 +13,188 @@ namespace Files.Filesystem
         public Visibility EmptyImgVis { get; set; }
         public BitmapImage FileImg { get; set; }
         public string FileName { get; set; }
-        public string FileDate { get; set; }
+        public string FileDate { get; private set; }
         public string FileType { get; set; }
         public string DotFileExtension { get; set; }
         public string FilePath { get; set; }
         public string FileSize { get; set; }
 
+        public DateTimeOffset FileDateReal
+        {
+            get { return _fileDataReal; }
+            set
+            {
+                FileDate = GetFriendlyDate(value.LocalDateTime);
+                _fileDataReal = value;
+            }
+        }
+
+        private DateTimeOffset _fileDataReal;
+
         public ListedItem(string folderRelativeId)
         {
             FolderRelativeId = folderRelativeId;
+        }
+
+        public static string GetFriendlyDate(DateTime d)
+        {
+            if (d.Year == DateTime.Now.Year)              // If item is accessed in the same year as stored
+            {
+                if (d.Month == DateTime.Now.Month)        // If item is accessed in the same month as stored
+                {
+                    if ((DateTime.Now.Day - d.Day) < 7) // If item is accessed on the same week
+                    {
+                        if (d.DayOfWeek == DateTime.Now.DayOfWeek)   // If item is accessed on the same day as stored
+                        {
+                            if ((DateTime.Now.Hour - d.Hour) > 1)
+                            {
+                                return DateTime.Now.Hour - d.Hour + " hours ago";
+                            }
+                            else
+                            {
+                                return DateTime.Now.Minute - d.Minute + " hour ago";
+                            }
+                        }
+                        else                                                        // If item is from a previous day of the same week
+                        {
+                            return d.DayOfWeek + " at " + d.ToShortTimeString();
+                        }
+                    }
+                    else                                                          // If item is from a previous week of the same month
+                    {
+                        string monthAsString = "Month";
+                        switch (d.Month)
+                        {
+                            case 1:
+                                monthAsString = "January";
+                                break;
+                            case 2:
+                                monthAsString = "February";
+                                break;
+                            case 3:
+                                monthAsString = "March";
+                                break;
+                            case 4:
+                                monthAsString = "April";
+                                break;
+                            case 5:
+                                monthAsString = "May";
+                                break;
+                            case 6:
+                                monthAsString = "June";
+                                break;
+                            case 7:
+                                monthAsString = "July";
+                                break;
+                            case 8:
+                                monthAsString = "August";
+                                break;
+                            case 9:
+                                monthAsString = "September";
+                                break;
+                            case 10:
+                                monthAsString = "October";
+                                break;
+                            case 11:
+                                monthAsString = "November";
+                                break;
+                            case 12:
+                                monthAsString = "December";
+                                break;
+                        }
+                        return monthAsString + " " + d.Day;
+                    }
+
+                }
+                else                                                            // If item is from a past month of the same year
+                {
+                    string monthAsString = "Month";
+                    switch (d.Month)
+                    {
+                        case 1:
+                            monthAsString = "January";
+                            break;
+                        case 2:
+                            monthAsString = "February";
+                            break;
+                        case 3:
+                            monthAsString = "March";
+                            break;
+                        case 4:
+                            monthAsString = "April";
+                            break;
+                        case 5:
+                            monthAsString = "May";
+                            break;
+                        case 6:
+                            monthAsString = "June";
+                            break;
+                        case 7:
+                            monthAsString = "July";
+                            break;
+                        case 8:
+                            monthAsString = "August";
+                            break;
+                        case 9:
+                            monthAsString = "September";
+                            break;
+                        case 10:
+                            monthAsString = "October";
+                            break;
+                        case 11:
+                            monthAsString = "November";
+                            break;
+                        case 12:
+                            monthAsString = "December";
+                            break;
+                    }
+                    return monthAsString + " " + d.Day;
+                }
+            }
+            else                                                                // If item is from a past year
+            {
+                string monthAsString = "Month";
+                switch (d.Month)
+                {
+                    case 1:
+                        monthAsString = "January";
+                        break;
+                    case 2:
+                        monthAsString = "February";
+                        break;
+                    case 3:
+                        monthAsString = "March";
+                        break;
+                    case 4:
+                        monthAsString = "April";
+                        break;
+                    case 5:
+                        monthAsString = "May";
+                        break;
+                    case 6:
+                        monthAsString = "June";
+                        break;
+                    case 7:
+                        monthAsString = "July";
+                        break;
+                    case 8:
+                        monthAsString = "August";
+                        break;
+                    case 9:
+                        monthAsString = "September";
+                        break;
+                    case 10:
+                        monthAsString = "October";
+                        break;
+                    case 11:
+                        monthAsString = "November";
+                        break;
+                    case 12:
+                        monthAsString = "December";
+                        break;
+                }
+                return monthAsString + " " + d.Day + ", " + d.Year;
+            }
         }
     }
 }

--- a/Files UWP/Filesystem/ListedItem.cs
+++ b/Files UWP/Filesystem/ListedItem.cs
@@ -5,6 +5,8 @@ namespace Files.Filesystem
 {
     public class ListedItem
     {
+        public string FolderRelativeId { get; }
+
         public Visibility FolderImg { get; set; }
         public Visibility FileIconVis { get; set; }
         public Visibility EmptyImgVis { get; set; }
@@ -15,9 +17,10 @@ namespace Files.Filesystem
         public string DotFileExtension { get; set; }
         public string FilePath { get; set; }
         public string FileSize { get; set; }
-        public ListedItem()
-        {
 
+        public ListedItem(string folderRelativeId)
+        {
+            FolderRelativeId = folderRelativeId;
         }
     }
 }

--- a/Files UWP/GenericFileBrowser.xaml.cs
+++ b/Files UWP/GenericFileBrowser.xaml.cs
@@ -112,7 +112,7 @@ namespace Files
         {
             base.OnNavigatedTo(eventArgs);
             var parameters = (string)eventArgs.Parameter;
-            App.ViewModel.FilesAndFolders.Clear();
+            App.ViewModel.CancelLoadAndClearFiles();
             App.ViewModel.Universal.path = parameters;
             App.ViewModel.AddItemsToCollectionAsync(App.ViewModel.Universal.path, GenericItemView);
             if (parameters.Equals(Environment.GetFolderPath(Environment.SpecialFolder.DesktopDirectory)))
@@ -332,11 +332,7 @@ namespace Files
                 var CurrentInput = PathBox.Text;
                 if (CurrentInput != App.ViewModel.Universal.path)
                 {
-                    if (!App.ViewModel.TokenSource.IsCancellationRequested)
-                    {
-                        App.ViewModel.TokenSource.Cancel();
-                        App.ViewModel.FilesAndFolders.Clear();
-                    }
+                    App.ViewModel.CancelLoadAndClearFiles();
 
                     if (CurrentInput == "Home" || CurrentInput == "home")
                     {

--- a/Files UWP/GenericFileBrowser.xaml.cs
+++ b/Files UWP/GenericFileBrowser.xaml.cs
@@ -332,9 +332,9 @@ namespace Files
                 var CurrentInput = PathBox.Text;
                 if (CurrentInput != App.ViewModel.Universal.path)
                 {
-                    if (App.ViewModel.tokenSource != null)
+                    if (!App.ViewModel.TokenSource.IsCancellationRequested)
                     {
-                        App.ViewModel.tokenSource.Cancel();
+                        App.ViewModel.TokenSource.Cancel();
                         App.ViewModel.FilesAndFolders.Clear();
                     }
 

--- a/Files UWP/Interacts/Interaction.cs
+++ b/Files UWP/Interacts/Interaction.cs
@@ -630,7 +630,7 @@ namespace Files.Interacts
                             App.ViewModel.AddFileOrFolder(new ListedItem(item.FolderRelativeId)
                             {
                                 FileName = input,
-                                FileDate = "Now",
+                                FileDateReal = DateTimeOffset.Now,
                                 EmptyImgVis = Visibility.Collapsed,
                                 FolderImg = Visibility.Visible,
                                 FileIconVis = Visibility.Collapsed,
@@ -647,7 +647,7 @@ namespace Files.Interacts
                             App.ViewModel.AddFileOrFolder(new ListedItem(item.FolderRelativeId)
                             {
                                 FileName = input,
-                                FileDate = "Now",
+                                FileDateReal = DateTimeOffset.Now,
                                 EmptyImgVis = Visibility.Visible,
                                 FolderImg = Visibility.Collapsed,
                                 FileIconVis = Visibility.Collapsed,
@@ -684,7 +684,7 @@ namespace Files.Interacts
                             App.ViewModel.AddFileOrFolder(new ListedItem(item.FolderRelativeId)
                             {
                                 FileName = input,
-                                FileDate = "Now",
+                                FileDateReal = DateTimeOffset.Now,
                                 EmptyImgVis = Visibility.Collapsed,
                                 FolderImg = Visibility.Visible,
                                 FileIconVis = Visibility.Collapsed,
@@ -701,7 +701,7 @@ namespace Files.Interacts
                             App.ViewModel.AddFileOrFolder(new ListedItem(item.FolderRelativeId)
                             {
                                 FileName = input,
-                                FileDate = "Now",
+                                FileDateReal = DateTimeOffset.Now,
                                 EmptyImgVis = Visibility.Visible,
                                 FolderImg = Visibility.Collapsed,
                                 FileIconVis = Visibility.Collapsed,

--- a/Files UWP/Interacts/Interaction.cs
+++ b/Files UWP/Interacts/Interaction.cs
@@ -20,6 +20,7 @@ using Windows.ApplicationModel;
 using System.Collections;
 using Windows.Foundation;
 using Windows.UI.Xaml.Controls.Primitives;
+using System.IO;
 
 namespace Files.Interacts
 {
@@ -60,7 +61,7 @@ namespace Files.Interacts
                         App.ViewModel.TextState.isVisible = Visibility.Collapsed;
                         History.ForwardList.Clear();
                         App.ViewModel.FS.isEnabled = false;
-                        App.ViewModel.FilesAndFolders.Clear();
+                        App.ViewModel.CancelLoadAndClearFiles();
                         if (clickedOnItem.FilePath == Environment.GetFolderPath(Environment.SpecialFolder.DesktopDirectory))
                         {
                             App.PathText.Text = "Desktop";
@@ -221,7 +222,7 @@ namespace Files.Interacts
                         App.ViewModel.TextState.isVisible = Visibility.Collapsed;
                         History.ForwardList.Clear();
                         App.ViewModel.FS.isEnabled = false;
-                        App.ViewModel.FilesAndFolders.Clear();
+                        App.ViewModel.CancelLoadAndClearFiles();
                         if (clickedOnItem.FilePath == Environment.GetFolderPath(Environment.SpecialFolder.DesktopDirectory))
                         {
                             App.PathText.Text = "Desktop";
@@ -454,7 +455,7 @@ namespace Files.Interacts
                     App.ViewModel.TextState.isVisible = Visibility.Collapsed;
                     History.ForwardList.Clear();
                     App.ViewModel.FS.isEnabled = false;
-                    App.ViewModel.FilesAndFolders.Clear();
+                    App.ViewModel.CancelLoadAndClearFiles();
                     App.ViewModel.Universal.path = RowData.FilePath;
                     App.ViewModel.AddItemsToCollectionAsync(App.ViewModel.Universal.path, GenericFileBrowser.GFBPageName);
                 }
@@ -476,7 +477,7 @@ namespace Files.Interacts
                     App.ViewModel.TextState.isVisible = Visibility.Collapsed;
                     History.ForwardList.Clear();
                     App.ViewModel.FS.isEnabled = false;
-                    App.ViewModel.FilesAndFolders.Clear();
+                    App.ViewModel.CancelLoadAndClearFiles();
                     App.ViewModel.Universal.path = RowData.FilePath;
                     App.ViewModel.AddItemsToCollectionAsync(RowData.FilePath, PhotoAlbum.PAPageName);
                 }
@@ -567,7 +568,7 @@ namespace Files.Interacts
                             await item.DeleteAsync(StorageDeleteOption.Default);
 
                         }
-                        App.ViewModel.FilesAndFolders.Remove(storItem);
+                        App.ViewModel.RemoveFileOrFolder(storItem);
                     }
                     Debug.WriteLine("Ended for loop");
                     History.ForwardList.Clear();
@@ -594,7 +595,7 @@ namespace Files.Interacts
                             await item.DeleteAsync(StorageDeleteOption.Default);
 
                         }
-                        App.ViewModel.FilesAndFolders.Remove(storItem);
+                        App.ViewModel.RemoveFileOrFolder(storItem);
                     }
                     Debug.WriteLine("Ended for loop");
                     History.ForwardList.Clear();
@@ -625,16 +626,36 @@ namespace Files.Interacts
                         {
                             var item = await StorageFolder.GetFolderFromPathAsync(RowData.FilePath);
                             await item.RenameAsync(input, NameCollisionOption.FailIfExists);
-                            App.ViewModel.FilesAndFolders.Remove(RowData);
-                            App.ViewModel.FilesAndFolders.Add(new ListedItem() { FileName = input, FileDate = "Now", EmptyImgVis = Visibility.Collapsed, FolderImg = Visibility.Visible, FileIconVis = Visibility.Collapsed, FileType = "Folder", FileImg = null, FilePath = (App.ViewModel.Universal.path + "\\" + input) });
+                            App.ViewModel.RemoveFileOrFolder(RowData);
+                            App.ViewModel.AddFileOrFolder(new ListedItem(item.FolderRelativeId)
+                            {
+                                FileName = input,
+                                FileDate = "Now",
+                                EmptyImgVis = Visibility.Collapsed,
+                                FolderImg = Visibility.Visible,
+                                FileIconVis = Visibility.Collapsed,
+                                FileType = "Folder",
+                                FileImg = null,
+                                FilePath = Path.Combine(App.ViewModel.Universal.path, input)
+                            });
                         }
                         else
                         {
                             var item = await StorageFile.GetFileFromPathAsync(RowData.FilePath);
                             await item.RenameAsync(input + RowData.DotFileExtension, NameCollisionOption.FailIfExists);
-                            App.ViewModel.FilesAndFolders.Remove(RowData);
-                            App.ViewModel.FilesAndFolders.Add(new ListedItem() { FileName = input, FileDate = "Now", EmptyImgVis = Visibility.Visible, FolderImg = Visibility.Collapsed, FileIconVis = Visibility.Collapsed, FileType = RowData.FileType, FileImg = null, FilePath = (App.ViewModel.Universal.path + "\\" + input + RowData.DotFileExtension), DotFileExtension = RowData.DotFileExtension });
-
+                            App.ViewModel.RemoveFileOrFolder(RowData);
+                            App.ViewModel.AddFileOrFolder(new ListedItem(item.FolderRelativeId)
+                            {
+                                FileName = input,
+                                FileDate = "Now",
+                                EmptyImgVis = Visibility.Visible,
+                                FolderImg = Visibility.Collapsed,
+                                FileIconVis = Visibility.Collapsed,
+                                FileType = RowData.FileType,
+                                FileImg = null,
+                                FilePath = Path.Combine(App.ViewModel.Universal.path, input + RowData.DotFileExtension),
+                                DotFileExtension = RowData.DotFileExtension
+                            });
                         }
                     }
 
@@ -659,16 +680,36 @@ namespace Files.Interacts
                         {
                             var item = await StorageFolder.GetFolderFromPathAsync(BoxData.FilePath);
                             await item.RenameAsync(input, NameCollisionOption.FailIfExists);
-                            App.ViewModel.FilesAndFolders.Remove(BoxData);
-                            App.ViewModel.FilesAndFolders.Add(new ListedItem() { FileName = input, FileDate = "Now", EmptyImgVis = Visibility.Collapsed, FolderImg = Visibility.Visible, FileIconVis = Visibility.Collapsed, FileType = "Folder", FileImg = null, FilePath = (App.ViewModel.Universal.path + "\\" + input) });
+                            App.ViewModel.RemoveFileOrFolder(BoxData);
+                            App.ViewModel.AddFileOrFolder(new ListedItem(item.FolderRelativeId)
+                            {
+                                FileName = input,
+                                FileDate = "Now",
+                                EmptyImgVis = Visibility.Collapsed,
+                                FolderImg = Visibility.Visible,
+                                FileIconVis = Visibility.Collapsed,
+                                FileType = "Folder",
+                                FileImg = null,
+                                FilePath = Path.Combine(App.ViewModel.Universal.path, input)
+                            });
                         }
                         else
                         {
                             var item = await StorageFile.GetFileFromPathAsync(BoxData.FilePath);
                             await item.RenameAsync(input + BoxData.DotFileExtension, NameCollisionOption.FailIfExists);
-                            App.ViewModel.FilesAndFolders.Remove(BoxData);
-                            App.ViewModel.FilesAndFolders.Add(new ListedItem() { FileName = input, FileDate = "Now", EmptyImgVis = Visibility.Visible, FolderImg = Visibility.Collapsed, FileIconVis = Visibility.Collapsed, FileType = BoxData.FileType, FileImg = null, FilePath = (App.ViewModel.Universal.path + "\\" + input + BoxData.DotFileExtension), DotFileExtension = BoxData.DotFileExtension });
-
+                            App.ViewModel.RemoveFileOrFolder(BoxData);
+                            App.ViewModel.AddFileOrFolder(new ListedItem(item.FolderRelativeId)
+                            {
+                                FileName = input,
+                                FileDate = "Now",
+                                EmptyImgVis = Visibility.Visible,
+                                FolderImg = Visibility.Collapsed,
+                                FileIconVis = Visibility.Collapsed,
+                                FileType = BoxData.FileType,
+                                FileImg = null,
+                                FilePath = Path.Combine(App.ViewModel.Universal.path, input + BoxData.DotFileExtension),
+                                DotFileExtension = BoxData.DotFileExtension
+                            });
                         }
                     }
 

--- a/Files UWP/MainPage.xaml.cs
+++ b/Files UWP/MainPage.xaml.cs
@@ -151,11 +151,8 @@ namespace Files
             }
             else
             {
-                if (!App.ViewModel.TokenSource.IsCancellationRequested)
-                {
-                    App.ViewModel.TokenSource.Cancel();
-                    App.ViewModel.FilesAndFolders.Clear();
-                }
+                App.ViewModel.CancelLoadAndClearFiles();
+
                 App.ViewModel.TextState.isVisible = Visibility.Collapsed;
                 if (item.ToString() == "Home")
                 {

--- a/Files UWP/MainPage.xaml.cs
+++ b/Files UWP/MainPage.xaml.cs
@@ -151,9 +151,9 @@ namespace Files
             }
             else
             {
-                if(App.ViewModel.tokenSource != null)
+                if (!App.ViewModel.TokenSource.IsCancellationRequested)
                 {
-                    App.ViewModel.tokenSource.Cancel();
+                    App.ViewModel.TokenSource.Cancel();
                     App.ViewModel.FilesAndFolders.Clear();
                 }
                 App.ViewModel.TextState.isVisible = Visibility.Collapsed;

--- a/Files UWP/Navigation/NavigationActions.cs
+++ b/Files UWP/Navigation/NavigationActions.cs
@@ -11,9 +11,9 @@ namespace Files.Navigation
     {
         public static void Back_Click(object sender, RoutedEventArgs e)
         {
-            if(App.ViewModel.tokenSource != null)
+            if (!App.ViewModel.TokenSource.IsCancellationRequested)
             {
-                App.ViewModel.tokenSource.Cancel();
+                App.ViewModel.TokenSource.Cancel();
             }
             App.ViewModel.FilesAndFolders.Clear();
 
@@ -160,13 +160,11 @@ namespace Files.Navigation
 
         public static void Forward_Click(object sender, RoutedEventArgs e)
         {
-            
-            if(App.ViewModel.tokenSource != null)
+            if (!App.ViewModel.TokenSource.IsCancellationRequested)
             {
-                App.ViewModel.tokenSource.Cancel();
+                App.ViewModel.TokenSource.Cancel();
             }
             App.ViewModel.FilesAndFolders.Clear();
-            
 
             if (History.ForwardList.Count() > 0)
             {
@@ -313,9 +311,9 @@ namespace Files.Navigation
         {
             await Windows.ApplicationModel.Core.CoreApplication.MainView.CoreWindow.Dispatcher.RunAsync(CoreDispatcherPriority.Normal, () =>
             {
-                if(App.ViewModel.tokenSource != null)
+                if (!App.ViewModel.TokenSource.IsCancellationRequested)
                 {
-                    App.ViewModel.tokenSource.Cancel();
+                    App.ViewModel.TokenSource.Cancel();
                 }
                 App.ViewModel.TextState.isVisible = Visibility.Collapsed;
                 App.ViewModel.FilesAndFolders.Clear();

--- a/Files UWP/Navigation/NavigationActions.cs
+++ b/Files UWP/Navigation/NavigationActions.cs
@@ -11,11 +11,7 @@ namespace Files.Navigation
     {
         public static void Back_Click(object sender, RoutedEventArgs e)
         {
-            if (!App.ViewModel.TokenSource.IsCancellationRequested)
-            {
-                App.ViewModel.TokenSource.Cancel();
-            }
-            App.ViewModel.FilesAndFolders.Clear();
+            App.ViewModel.CancelLoadAndClearFiles();
 
             if (History.HistoryList.Count > 1)
             {
@@ -24,7 +20,7 @@ namespace Files.Navigation
                 History.AddToForwardList(History.HistoryList[History.HistoryList.Count - 1]);
                 History.HistoryList.RemoveAt(History.HistoryList.Count - 1);
 
-                App.ViewModel.FilesAndFolders.Clear();
+                App.ViewModel.CancelLoadAndClearFiles();
 
                 // If the item we are navigating back to is a specific library, accomodate this.
                 if ((History.HistoryList[History.HistoryList.Count - 1]) == Environment.GetFolderPath(Environment.SpecialFolder.DesktopDirectory))
@@ -160,17 +156,12 @@ namespace Files.Navigation
 
         public static void Forward_Click(object sender, RoutedEventArgs e)
         {
-            if (!App.ViewModel.TokenSource.IsCancellationRequested)
-            {
-                App.ViewModel.TokenSource.Cancel();
-            }
-            App.ViewModel.FilesAndFolders.Clear();
+            App.ViewModel.CancelLoadAndClearFiles();
 
             if (History.ForwardList.Count() > 0)
             {
                 App.ViewModel.TextState.isVisible = Visibility.Collapsed;
-                App.ViewModel.FilesAndFolders.Clear();
-
+                App.ViewModel.CancelLoadAndClearFiles();
 
                 if ((History.ForwardList[History.ForwardList.Count() - 1]) == Environment.GetFolderPath(Environment.SpecialFolder.DesktopDirectory))
                 {
@@ -311,12 +302,9 @@ namespace Files.Navigation
         {
             await Windows.ApplicationModel.Core.CoreApplication.MainView.CoreWindow.Dispatcher.RunAsync(CoreDispatcherPriority.Normal, () =>
             {
-                if (!App.ViewModel.TokenSource.IsCancellationRequested)
-                {
-                    App.ViewModel.TokenSource.Cancel();
-                }
+                App.ViewModel.CancelLoadAndClearFiles();
+
                 App.ViewModel.TextState.isVisible = Visibility.Collapsed;
-                App.ViewModel.FilesAndFolders.Clear();
                 App.ViewModel.AddItemsToCollectionAsync(App.ViewModel.Universal.path, GenericFileBrowser.GFBPageName);
                 if ((History.HistoryList[History.HistoryList.Count - 1]) == Environment.GetFolderPath(Environment.SpecialFolder.DesktopDirectory))
                 {

--- a/Files UWP/Navigation/PhotoAlbumNavActions.cs
+++ b/Files UWP/Navigation/PhotoAlbumNavActions.cs
@@ -13,19 +13,14 @@ namespace Files.Navigation
     {
         public static void Back_Click(object sender, RoutedEventArgs e)
         {
-            if (!App.ViewModel.TokenSource.IsCancellationRequested)
-            {
-                App.ViewModel.TokenSource.Cancel();
-            }
-            App.ViewModel.FilesAndFolders.Clear();
-            
+            App.ViewModel.CancelLoadAndClearFiles();
 
             if (History.HistoryList.Count() > 1)
             {
                 App.ViewModel.TextState.isVisible = Visibility.Collapsed;
                 History.AddToForwardList(History.HistoryList[History.HistoryList.Count() - 1]);
                 History.HistoryList.RemoveAt(History.HistoryList.Count() - 1);
-                App.ViewModel.FilesAndFolders.Clear();
+                App.ViewModel.CancelLoadAndClearFiles();
 
                 if ((History.HistoryList[History.HistoryList.Count - 1]) == Environment.GetFolderPath(Environment.SpecialFolder.DesktopDirectory))
                 {
@@ -160,17 +155,12 @@ namespace Files.Navigation
 
         public static void Forward_Click(object sender, RoutedEventArgs e)
         {
-            if (!App.ViewModel.TokenSource.IsCancellationRequested)
-            {
-                App.ViewModel.TokenSource.Cancel();
-            }
-            App.ViewModel.FilesAndFolders.Clear();
+            App.ViewModel.CancelLoadAndClearFiles();
 
             if (History.ForwardList.Count() > 0)
             {
                 App.ViewModel.TextState.isVisible = Visibility.Collapsed;
-                App.ViewModel.FilesAndFolders.Clear();
-
+                App.ViewModel.CancelLoadAndClearFiles();
 
                 if ((History.ForwardList[History.ForwardList.Count() - 1]) == Environment.GetFolderPath(Environment.SpecialFolder.DesktopDirectory))
                 {
@@ -310,12 +300,9 @@ namespace Files.Navigation
         {
             await Windows.ApplicationModel.Core.CoreApplication.MainView.CoreWindow.Dispatcher.RunAsync(CoreDispatcherPriority.Normal, () =>
             {
-                if (!App.ViewModel.TokenSource.IsCancellationRequested)
-                {
-                    App.ViewModel.TokenSource.Cancel();
-                }
+                App.ViewModel.CancelLoadAndClearFiles();
+
                 App.ViewModel.TextState.isVisible = Visibility.Collapsed;
-                App.ViewModel.FilesAndFolders.Clear();
                 App.ViewModel.AddItemsToCollectionAsync(App.PathText.Text, PhotoAlbum.PAPageName);
                 if ((History.HistoryList[History.HistoryList.Count - 1]) == Environment.GetFolderPath(Environment.SpecialFolder.DesktopDirectory))
                 {

--- a/Files UWP/Navigation/PhotoAlbumNavActions.cs
+++ b/Files UWP/Navigation/PhotoAlbumNavActions.cs
@@ -13,10 +13,9 @@ namespace Files.Navigation
     {
         public static void Back_Click(object sender, RoutedEventArgs e)
         {
-            
-            if(App.ViewModel.tokenSource != null)
+            if (!App.ViewModel.TokenSource.IsCancellationRequested)
             {
-                App.ViewModel.tokenSource.Cancel();
+                App.ViewModel.TokenSource.Cancel();
             }
             App.ViewModel.FilesAndFolders.Clear();
             
@@ -161,9 +160,9 @@ namespace Files.Navigation
 
         public static void Forward_Click(object sender, RoutedEventArgs e)
         {
-            if(App.ViewModel.tokenSource != null)
+            if (!App.ViewModel.TokenSource.IsCancellationRequested)
             {
-                App.ViewModel.tokenSource.Cancel();
+                App.ViewModel.TokenSource.Cancel();
             }
             App.ViewModel.FilesAndFolders.Clear();
 
@@ -311,9 +310,9 @@ namespace Files.Navigation
         {
             await Windows.ApplicationModel.Core.CoreApplication.MainView.CoreWindow.Dispatcher.RunAsync(CoreDispatcherPriority.Normal, () =>
             {
-                if(App.ViewModel.tokenSource != null)
+                if (!App.ViewModel.TokenSource.IsCancellationRequested)
                 {
-                    App.ViewModel.tokenSource.Cancel();
+                    App.ViewModel.TokenSource.Cancel();
                 }
                 App.ViewModel.TextState.isVisible = Visibility.Collapsed;
                 App.ViewModel.FilesAndFolders.Clear();

--- a/Files UWP/PhotoAlbum.xaml.cs
+++ b/Files UWP/PhotoAlbum.xaml.cs
@@ -129,11 +129,7 @@ namespace Files
                 var CurrentInput = PathBox.Text;
                 if (CurrentInput != App.ViewModel.Universal.path)
                 {
-                    if (!App.ViewModel.TokenSource.IsCancellationRequested)
-                    {
-                        App.ViewModel.TokenSource.Cancel();
-                        App.ViewModel.FilesAndFolders.Clear();
-                    }
+                    App.ViewModel.CancelLoadAndClearFiles();
 
                     if (CurrentInput == "Home" || CurrentInput == "home")
                     {

--- a/Files UWP/PhotoAlbum.xaml.cs
+++ b/Files UWP/PhotoAlbum.xaml.cs
@@ -129,9 +129,9 @@ namespace Files
                 var CurrentInput = PathBox.Text;
                 if (CurrentInput != App.ViewModel.Universal.path)
                 {
-                    if (App.ViewModel.tokenSource != null)
+                    if (!App.ViewModel.TokenSource.IsCancellationRequested)
                     {
-                        App.ViewModel.tokenSource.Cancel();
+                        App.ViewModel.TokenSource.Cancel();
                         App.ViewModel.FilesAndFolders.Clear();
                     }
 


### PR DESCRIPTION
This PR aims to fix #6, fix #55.Filesystem changes will be automatically reflected. There are also some code refactors, some were necessary others are just good practices like reducing publicly accessible things.

Performance is good enough for a moderately sized folder. However it's not optimal. There are two broad changes that can be made to improve performance (not just for auto refresh but in general):
1) Expose files and folders as separate lists. UWP treats file and folder as very different types and provides separate api to work with them so it makes sense to split them in the code as well.
2) Use a different observable collection like dictionary or hashset. Of course these don't exist by default so we'll have to write one ourselves.