### PR TITLE
Add new file/folder buttons in right-click context menu

### DIFF
--- a/Files UWP/AddItem.xaml.cs
+++ b/Files UWP/AddItem.xaml.cs
@@ -54,10 +54,16 @@ namespace Files
             }
             return default;
         }
-        private async void ListView_ItemClick(object sender, ItemClickEventArgs e)
+
+        private void ListView_ItemClick(object sender, ItemClickEventArgs e)
         {
             var TabInstance = App.selectedTabInstance;
             TabInstance.addItemDialog.Hide();
+            CreateFile(TabInstance, (e.ClickedItem as AddListItem).Header);
+        }
+
+        public static async void CreateFile(ProHome TabInstance, String fileType)
+        {
             string currentPath = null;
             if (TabInstance.accessibleContentFrame.SourcePageType == typeof(GenericFileBrowser))
             {
@@ -69,14 +75,16 @@ namespace Files
             }
             StorageFolder folderToCreateItem = await StorageFolder.GetFolderFromPathAsync(currentPath);
             RenameDialog renameDialog = new RenameDialog();
-            if ((e.ClickedItem as AddListItem).Header == "Folder")
+
+            await renameDialog.ShowAsync();
+            var userInput = renameDialog.storedRenameInput;
+
+            if (fileType == "Folder")
             {
-                await renameDialog.ShowAsync();
-                var userInput = renameDialog.storedRenameInput;
                 if (userInput != "")
                 {
                     var folder = await folderToCreateItem.CreateFolderAsync(userInput, CreationCollisionOption.FailIfExists);
-                    TabInstance.instanceViewModel.AddFileOrFolder(new ListedItem(folder.FolderRelativeId){ FileName = userInput, FileDateReal = DateTimeOffset.Now, EmptyImgVis = Visibility.Collapsed, FolderImg = Visibility.Visible, FileIconVis = Visibility.Collapsed, FileType = "Folder", FileImg = null, FilePath = (TabInstance.instanceViewModel.Universal.path + "\\" + userInput) });
+                    TabInstance.instanceViewModel.AddFileOrFolder(new ListedItem(folder.FolderRelativeId) { FileName = userInput, FileDateReal = DateTimeOffset.Now, EmptyImgVis = Visibility.Collapsed, FolderImg = Visibility.Visible, FileIconVis = Visibility.Collapsed, FileType = "Folder", FileImg = null, FilePath = (TabInstance.instanceViewModel.Universal.path + "\\" + userInput) });
                 }
                 else
                 {
@@ -84,10 +92,8 @@ namespace Files
                     TabInstance.instanceViewModel.AddFileOrFolder(new ListedItem(folder.FolderRelativeId) { FileName = userInput, FileDateReal = DateTimeOffset.Now, EmptyImgVis = Visibility.Collapsed, FolderImg = Visibility.Visible, FileIconVis = Visibility.Collapsed, FileType = "Folder", FileImg = null, FilePath = (TabInstance.instanceViewModel.Universal.path + "\\" + userInput) });
                 }
             }
-            else if ((e.ClickedItem as AddListItem).Header == "Text Document")
+            else if (fileType == "Text Document")
             {
-                await renameDialog.ShowAsync();
-                var userInput = renameDialog.storedRenameInput;
                 if (userInput != "")
                 {
                     var folder = await folderToCreateItem.CreateFileAsync(userInput + ".txt", CreationCollisionOption.FailIfExists);
@@ -99,10 +105,8 @@ namespace Files
                     TabInstance.instanceViewModel.AddFileOrFolder(new ListedItem(folder.FolderRelativeId) { FileName = userInput, FileDateReal = DateTimeOffset.Now, EmptyImgVis = Visibility.Visible, FolderImg = Visibility.Collapsed, FileIconVis = Visibility.Collapsed, FileType = "Text Document", FileImg = null, FilePath = (TabInstance.instanceViewModel.Universal.path + "\\" + userInput + ".txt"), DotFileExtension = ".txt" });
                 }
             }
-            else if ((e.ClickedItem as AddListItem).Header == "Bitmap Image")
+            else if (fileType == "Bitmap Image")
             {
-                await renameDialog.ShowAsync();
-                var userInput = renameDialog.storedRenameInput;
                 if (userInput != "")
                 {
                     var folder = await folderToCreateItem.CreateFileAsync(userInput + ".bmp", CreationCollisionOption.FailIfExists);

--- a/Files UWP/GenericFileBrowser.xaml
+++ b/Files UWP/GenericFileBrowser.xaml
@@ -167,11 +167,34 @@
                         <KeyboardAccelerator Modifiers="Control" Key="V"/>
                     </MenuFlyoutItem.KeyboardAccelerators>
                 </MenuFlyoutItem>
+                <MenuFlyoutSeparator/>
                 <MenuFlyoutItem x:Name="OpenTerminal" IsEnabled="True" Text="Open in Terminal...">
                     <MenuFlyoutItem.Icon>
                         <FontIcon Glyph="&#xE756;"/>
                     </MenuFlyoutItem.Icon>
                 </MenuFlyoutItem>
+                <MenuFlyoutSeparator/>
+                <MenuFlyoutSubItem Text="New" x:Name="NewEmptySpace">
+                    <MenuFlyoutSubItem.Icon>
+                        <FontIcon Glyph="&#xE710;"/>
+                    </MenuFlyoutSubItem.Icon>
+                    <MenuFlyoutItem Text="Folder" x:Name="NewFolder">
+                        <MenuFlyoutItem.Icon>
+                            <FontIcon Glyph="&#xE8B7;"/>
+                        </MenuFlyoutItem.Icon>
+                    </MenuFlyoutItem>
+                    <MenuFlyoutSeparator/>
+                    <MenuFlyoutItem Text="Bitmap Image" x:Name="NewBitmapImage">
+                        <MenuFlyoutItem.Icon>
+                            <FontIcon Glyph="&#xEB9F;"/>
+                        </MenuFlyoutItem.Icon>
+                    </MenuFlyoutItem>
+                    <MenuFlyoutItem Text="Text Document" x:Name="NewTextDocument">
+                        <MenuFlyoutItem.Icon>
+                            <FontIcon Glyph="&#xE8A5;"/>
+                        </MenuFlyoutItem.Icon>
+                    </MenuFlyoutItem>
+                </MenuFlyoutSubItem>
             </MenuFlyout>
         </Grid.ContextFlyout>
         <ProgressBar x:Name="progBar" Height="10" VerticalAlignment="Top" IsIndeterminate="True"/>

--- a/Files UWP/GenericFileBrowser.xaml.cs
+++ b/Files UWP/GenericFileBrowser.xaml.cs
@@ -72,6 +72,9 @@ namespace Files
             AllView.RightTapped += tabInstance.instanceInteraction.AllView_RightTapped;
             AllView.DoubleTapped += tabInstance.instanceInteraction.List_ItemClick;
             OpenTerminal.Click += tabInstance.instanceInteraction.OpenDirectoryInTerminal;
+            NewFolder.Click += tabInstance.instanceInteraction.NewFolder_Click;
+            NewBitmapImage.Click += tabInstance.instanceInteraction.NewBitmapImage_Click;
+            NewTextDocument.Click += tabInstance.instanceInteraction.NewTextDocument_Click;
             PropertiesItem.Click += tabInstance.ShowPropertiesButton_Click;
             OpenInNewWindowItem.Click += tabInstance.instanceInteraction.OpenInNewWindowItem_Click;
         }

--- a/Files UWP/Interacts/Interaction.cs
+++ b/Files UWP/Interacts/Interaction.cs
@@ -1212,6 +1212,21 @@ namespace Files.Interacts
             } 
         }
 
+        public void NewFolder_Click(object sender, RoutedEventArgs e)
+        {
+            AddItem.CreateFile(tabInstance, "Folder");
+        }
+
+        public void NewTextDocument_Click(object sender, RoutedEventArgs e)
+        {
+            AddItem.CreateFile(tabInstance, "Text Document");
+        }
+
+        public void NewBitmapImage_Click(object sender, RoutedEventArgs e)
+        {
+            AddItem.CreateFile(tabInstance, "Bitmap Image");
+        }
+
         public void SelectAllItems()
         {
             if(App.selectedTabInstance.accessibleContentFrame.SourcePageType == typeof(GenericFileBrowser))


### PR DESCRIPTION
Adds "New folder", "New Text Document" and "New Bitmap Image" to the right click menu. Once clicked, they trigger the same `RenameDialog` as when creating the items from the "Add Item" button in the ribbon.

## Screenshots

| Before | After |
|--------|-------|
|  ![image](https://user-images.githubusercontent.com/8487294/67417228-e4288280-f5fa-11e9-9bd0-f19935db616a.png) | ![image](https://user-images.githubusercontent.com/8487294/67416855-2dc49d80-f5fa-11e9-8f73-bb439c19f7a1.png) |

Related to:
- #49 
- #220 