### PR TITLE
Add sorting to PhotoAlbum

### DIFF
--- a/Files UWP/Enums/SortOption.cs
+++ b/Files UWP/Enums/SortOption.cs
@@ -1,0 +1,10 @@
+﻿namespace Files.Enums
+{
+    public enum SortOption
+    {
+        Name,
+        DateModified,
+        Size,
+        FileType
+    }
+}

--- a/Files UWP/FilesUWP.csproj
+++ b/Files UWP/FilesUWP.csproj
@@ -140,6 +140,7 @@
     <Compile Include="Dialogs\RenameDialog.xaml.cs">
       <DependentUpon>RenameDialog.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Enums\SortOption.cs" />
     <Compile Include="Enums\ThemeStyle.cs" />
     <Compile Include="Enums\TimeStyle.cs" />
     <Compile Include="Filesystem\DriveItem.cs" />

--- a/Files UWP/Interacts/Interaction.cs
+++ b/Files UWP/Interacts/Interaction.cs
@@ -43,10 +43,9 @@ namespace Files.Interacts
             {
                 if (App.selectedTabInstance.accessibleContentFrame.SourcePageType == typeof(GenericFileBrowser))
                 {
-                    var index = (tabInstance.accessibleContentFrame.Content as GenericFileBrowser).data.SelectedIndex;
-                    if (index > -1)
+                    var clickedOnItem = (tabInstance.accessibleContentFrame.Content as GenericFileBrowser).data.SelectedItem as ListedItem;
+                    if (clickedOnItem != null)
                     {
-                        var clickedOnItem = tabInstance.instanceViewModel.FilesAndFolders[index];
                         // Access MRU List
                         var mostRecentlyUsed = Windows.Storage.AccessCache.StorageApplicationPermissions.MostRecentlyUsedList;
 
@@ -141,11 +140,10 @@ namespace Files.Interacts
                 }
                 else if (App.selectedTabInstance.accessibleContentFrame.SourcePageType == typeof(PhotoAlbum))
                 {
-                    var index = (tabInstance.accessibleContentFrame.Content as PhotoAlbum).gv.SelectedIndex;
+                    var clickedOnItem = (tabInstance.accessibleContentFrame.Content as PhotoAlbum).gv.SelectedItem as ListedItem;
                     var CurrentInstance = App.selectedTabInstance;
-                    if (index > -1)
+                    if (clickedOnItem != null)
                     {
-                        var clickedOnItem = tabInstance.instanceViewModel.FilesAndFolders[index];
                         // Access MRU List
                         var mostRecentlyUsed = Windows.Storage.AccessCache.StorageApplicationPermissions.MostRecentlyUsedList;
 

--- a/Files UWP/PhotoAlbum.xaml
+++ b/Files UWP/PhotoAlbum.xaml
@@ -8,6 +8,7 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:controls="using:Microsoft.Toolkit.Uwp.UI.Controls"
+    xmlns:uilib="using:Microsoft.UI.Xaml.Controls"
     xmlns:animations="using:Microsoft.Toolkit.Uwp.UI.Animations"
     xmlns:Interactivity="using:Microsoft.Xaml.Interactivity"
     xmlns:Core="using:Microsoft.Xaml.Interactions.Core"
@@ -383,6 +384,18 @@
         <Grid.ContextFlyout>
             <MenuFlyout x:Name="GridRightClickContextMenu" MenuFlyoutPresenterStyle="{StaticResource MenuFlyoutFluentThemeResources}">
                 <MenuFlyout.Items>
+                    <MenuFlyoutSubItem Text="Sort by" x:Name="SortByGrid">
+                        <MenuFlyoutSubItem.Icon>
+                            <FontIcon Glyph="&#xE8CB;"/>
+                        </MenuFlyoutSubItem.Icon>
+                        <uilib:RadioMenuFlyoutItem Text="Name" GroupName="SortGroup" IsChecked="{x:Bind IsSortedByName, Mode=TwoWay}"/>
+                        <uilib:RadioMenuFlyoutItem Text="Date modified" GroupName="SortGroup" IsChecked="{x:Bind IsSortedByDate, Mode=TwoWay}"/>
+                        <uilib:RadioMenuFlyoutItem Text="Type" GroupName="SortGroup" IsChecked="{x:Bind IsSortedByType, Mode=TwoWay}"/>
+                        <uilib:RadioMenuFlyoutItem Text="Size" GroupName="SortGroup" IsChecked="{x:Bind IsSortedBySize, Mode=TwoWay}"/>
+                        <MenuFlyoutSeparator/>
+                        <uilib:RadioMenuFlyoutItem Text="Ascending" GroupName="SortOrderGroup" IsChecked="{x:Bind IsSortedAscending, Mode=TwoWay}"/>
+                        <uilib:RadioMenuFlyoutItem Text="Descending" GroupName="SortOrderGroup" IsChecked="{x:Bind IsSortedDescending, Mode=TwoWay}"/>
+                    </MenuFlyoutSubItem>
                     <MenuFlyoutItem Click="RefreshGrid_Click" Text="Refresh" Name="RefreshGrid">
                         <MenuFlyoutItem.Icon>
                             <FontIcon Glyph="&#xE72C;"/>
@@ -397,6 +410,7 @@
                             <KeyboardAccelerator Modifiers="Control" Key="V"/>
                         </MenuFlyoutItem.KeyboardAccelerators>
                     </MenuFlyoutItem>
+                    <MenuFlyoutSeparator/>
                     <MenuFlyoutItem x:Name="OpenTerminal" IsEnabled="True" Text="Open in Terminal...">
                         <MenuFlyoutItem.Icon>
                             <FontIcon Glyph="&#xE756;"/>

--- a/Files UWP/PhotoAlbum.xaml.cs
+++ b/Files UWP/PhotoAlbum.xaml.cs
@@ -2,13 +2,14 @@
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Navigation;
+using Files.Enums;
 using Files.Filesystem;
-using Files.Interacts;
 using Windows.UI.Xaml.Input;
 using Windows.UI.Popups;
 using System.IO;
 using Windows.Storage;
 using Windows.System;
+using Microsoft.Toolkit.Uwp.UI;
 using Microsoft.Toolkit.Uwp.UI.Controls;
 using Windows.ApplicationModel.DataTransfer;
 using Files.Navigation;
@@ -45,6 +46,34 @@ namespace Files
         ProHome tabInstance;
         public EmptyFolderTextState TextState { get; set; } = new EmptyFolderTextState();
 
+        private bool IsSortedByName { get { return viewModelInstance.DirectorySortOption == SortOption.Name; } set { if (value) viewModelInstance.DirectorySortOption = SortOption.Name; } }
+        private bool IsSortedByDate { get { return viewModelInstance.DirectorySortOption == SortOption.DateModified; } set { if (value) viewModelInstance.DirectorySortOption = SortOption.DateModified; } }
+        private bool IsSortedByType { get { return viewModelInstance.DirectorySortOption == SortOption.FileType; } set { if (value) viewModelInstance.DirectorySortOption = SortOption.FileType; } }
+        private bool IsSortedBySize { get { return viewModelInstance.DirectorySortOption == SortOption.Size; } set { if (value) viewModelInstance.DirectorySortOption = SortOption.Size; } }
+        
+        private bool IsSortedAscending
+        {
+            get
+            {
+                return viewModelInstance.DirectorySortDirection == SortDirection.Ascending;
+            }
+            set
+            {
+                viewModelInstance.DirectorySortDirection = value ? SortDirection.Ascending : SortDirection.Descending;
+            }
+        }
+
+        private bool IsSortedDescending
+        {
+            get
+            {
+                return !IsSortedAscending;
+            }
+            set
+            {
+                IsSortedAscending = !value;
+            }
+        }
 
         public PhotoAlbum()
         {


### PR DESCRIPTION
# Changes
- Adds "Sort by" to right click menu in PhotoAlbum.
- Adds `SortOption` enum to represent current file attribute to sort by
- Moves sorting logic to `ItemViewModel` from `GenericFileBrowser`. This allows sorting options to persist through folder navigation

![image](https://user-images.githubusercontent.com/8487294/67697715-f3854280-f9e3-11e9-919e-5bbb80d56688.png)

# Issues
- Sort button not yet added in ribbon
- Navigating to another folder currently
  sorts its files only after all of them
  are loaded.