### PR TITLE
Add sort button to app ribbon

### DIFF
--- a/Files UWP/Filesystem/ItemViewModel.cs
+++ b/Files UWP/Filesystem/ItemViewModel.cs
@@ -6,10 +6,12 @@ using Microsoft.UI.Xaml.Controls;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.ComponentModel;
 using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
@@ -31,7 +33,7 @@ using TreeView = Microsoft.UI.Xaml.Controls.TreeView;
 
 namespace Files.Filesystem
 {
-    public class ItemViewModel
+    public class ItemViewModel : INotifyPropertyChanged
     {
         public ReadOnlyObservableCollection<ListedItem> FilesAndFolders { get; }
         public CollectionViewSource viewSource;
@@ -44,6 +46,7 @@ namespace Files.Filesystem
         private QueryOptions _options;
         private volatile bool _filesRefreshing;
         private const int _step = 250;
+        public event PropertyChangedEventHandler PropertyChanged;
 
         private SortOption _directorySortOption = SortOption.Name;
         private SortDirection _directorySortDirection = SortDirection.Ascending;
@@ -59,6 +62,11 @@ namespace Files.Filesystem
                 if (value != _directorySortOption)
                 {
                     _directorySortOption = value;
+                    NotifyPropertyChanged("DirectorySortOption");
+                    NotifyPropertyChanged("IsSortedByName");
+                    NotifyPropertyChanged("IsSortedByDate");
+                    NotifyPropertyChanged("IsSortedByType");
+                    NotifyPropertyChanged("IsSortedBySize");
                     OrderFiles();
                 }
             }
@@ -75,8 +83,91 @@ namespace Files.Filesystem
                 if (value != _directorySortDirection)
                 {
                     _directorySortDirection = value;
+                    NotifyPropertyChanged("DirectorySortDirection");
+                    NotifyPropertyChanged("IsSortedAscending");
+                    NotifyPropertyChanged("IsSortedDescending");
                     OrderFiles();
                 }
+            }
+        }
+
+        public bool IsSortedByName
+        {
+            get => DirectorySortOption == SortOption.Name;
+            set
+            {
+                if (value)
+                {
+                    DirectorySortOption = SortOption.Name;
+                    NotifyPropertyChanged("IsSortedByName");
+                    NotifyPropertyChanged("DirectorySortOption");
+                }
+            }
+        }
+
+        public bool IsSortedByDate
+        {
+            get => DirectorySortOption == SortOption.DateModified;
+            set
+            {
+                if (value)
+                {
+                    DirectorySortOption = SortOption.DateModified;
+                    NotifyPropertyChanged("IsSortedByDate");
+                    NotifyPropertyChanged("DirectorySortOption");
+                }
+            }
+        }
+
+        public bool IsSortedByType
+        {
+            get => DirectorySortOption == SortOption.FileType;
+            set
+            {
+                if (value)
+                {
+                    DirectorySortOption = SortOption.FileType;
+                    NotifyPropertyChanged("IsSortedByType");
+                    NotifyPropertyChanged("DirectorySortOption");
+                }
+            }
+        }
+
+        public bool IsSortedBySize
+        {
+            get => DirectorySortOption == SortOption.Size;
+            set
+            {
+                if (value)
+                {
+                    DirectorySortOption = SortOption.Size;
+                    NotifyPropertyChanged("IsSortedBySize");
+                    NotifyPropertyChanged("DirectorySortOption");
+                }
+            }
+        }
+
+        public bool IsSortedAscending
+        {
+            get => DirectorySortDirection == SortDirection.Ascending;
+            set
+            {
+                DirectorySortDirection = value ? SortDirection.Ascending : SortDirection.Descending;
+                NotifyPropertyChanged("IsSortedAscending");
+                NotifyPropertyChanged("IsSortedDescending");
+                NotifyPropertyChanged("DirectorySortDirection");
+            }
+        }
+
+        public bool IsSortedDescending
+        {
+            get => !IsSortedAscending;
+            set
+            {
+                DirectorySortDirection = value ? SortDirection.Descending : SortDirection.Ascending;
+                NotifyPropertyChanged("IsSortedAscending");
+                NotifyPropertyChanged("IsSortedDescending");
+                NotifyPropertyChanged("DirectorySortDirection");
             }
         }
 
@@ -812,6 +903,10 @@ namespace Files.Filesystem
 
             _filesRefreshing = false;
             Debug.WriteLine("Filesystem refresh complete");
+        }
+        private void NotifyPropertyChanged([CallerMemberName] string propertyName = "")
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
         }
     }
 }

--- a/Files UWP/GenericFileBrowser.xaml
+++ b/Files UWP/GenericFileBrowser.xaml
@@ -158,13 +158,13 @@
                     <MenuFlyoutSubItem.Icon>
                         <FontIcon Glyph="&#xE8CB;"/>
                     </MenuFlyoutSubItem.Icon>
-                    <uilib:RadioMenuFlyoutItem Text="Name" GroupName="SortGroup" IsChecked="{x:Bind IsSortedByName, Mode=TwoWay}"/>
-                    <uilib:RadioMenuFlyoutItem Text="Date modified" GroupName="SortGroup" IsChecked="{x:Bind IsSortedByDate, Mode=TwoWay}"/>
-                    <uilib:RadioMenuFlyoutItem Text="Type" GroupName="SortGroup" IsChecked="{x:Bind IsSortedByType, Mode=TwoWay}"/>
-                    <uilib:RadioMenuFlyoutItem Text="Size" GroupName="SortGroup" IsChecked="{x:Bind IsSortedBySize, Mode=TwoWay}"/>
+                    <uilib:RadioMenuFlyoutItem Text="Name" GroupName="SortGroup" IsChecked="{x:Bind viewModelInstance.IsSortedByName, Mode=TwoWay}"/>
+                    <uilib:RadioMenuFlyoutItem Text="Date modified" GroupName="SortGroup" IsChecked="{x:Bind viewModelInstance.IsSortedByDate, Mode=TwoWay}"/>
+                    <uilib:RadioMenuFlyoutItem Text="Type" GroupName="SortGroup" IsChecked="{x:Bind viewModelInstance.IsSortedByType, Mode=TwoWay}"/>
+                    <uilib:RadioMenuFlyoutItem Text="Size" GroupName="SortGroup" IsChecked="{x:Bind viewModelInstance.IsSortedBySize, Mode=TwoWay}"/>
                     <MenuFlyoutSeparator/>
-                    <uilib:RadioMenuFlyoutItem Text="Ascending" GroupName="SortOrderGroup" IsChecked="{x:Bind IsSortedAscending, Mode=TwoWay}"/>
-                    <uilib:RadioMenuFlyoutItem Text="Descending" GroupName="SortOrderGroup" IsChecked="{x:Bind IsSortedDescending, Mode=TwoWay}"/>
+                    <uilib:RadioMenuFlyoutItem Text="Ascending" GroupName="SortOrderGroup" IsChecked="{x:Bind viewModelInstance.IsSortedAscending, Mode=TwoWay}"/>
+                    <uilib:RadioMenuFlyoutItem Text="Descending" GroupName="SortOrderGroup" IsChecked="{x:Bind viewModelInstance.IsSortedDescending, Mode=TwoWay}"/>
                 </MenuFlyoutSubItem>
                 <MenuFlyoutItem Text="Refresh" x:Name="RefreshEmptySpace">
                     <MenuFlyoutItem.Icon>

--- a/Files UWP/Interacts/ItemInteractions.cs
+++ b/Files UWP/Interacts/ItemInteractions.cs
@@ -1,4 +1,5 @@
 ﻿using System.ComponentModel;
+using System.Runtime.CompilerServices;
 
 namespace Files.Interacts
 {
@@ -23,9 +24,9 @@ namespace Files.Interacts
         }
         public event PropertyChangedEventHandler PropertyChanged;
 
-        private void NotifyPropertyChanged(string info)
+        private void NotifyPropertyChanged([CallerMemberName] string propertyName = "")
         {
-            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(info));
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
         }
     }
 
@@ -50,9 +51,9 @@ namespace Files.Interacts
         }
         public event PropertyChangedEventHandler PropertyChanged;
 
-        private void NotifyPropertyChanged(string info)
+        private void NotifyPropertyChanged([CallerMemberName] string propertyName = "")
         {
-            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(info));
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
         }
     }
 
@@ -77,9 +78,9 @@ namespace Files.Interacts
         }
         public event PropertyChangedEventHandler PropertyChanged;
 
-        private void NotifyPropertyChanged(string info)
+        private void NotifyPropertyChanged([CallerMemberName] string propertyName = "")
         {
-            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(info));
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
         }
     }
 }

--- a/Files UWP/Interacts/RibbonActions/Home.cs
+++ b/Files UWP/Interacts/RibbonActions/Home.cs
@@ -1,4 +1,5 @@
 ﻿using System.ComponentModel;
+using System.Runtime.CompilerServices;
 
 namespace Files.Interacts.Home
 {
@@ -23,9 +24,9 @@ namespace Files.Interacts.Home
         }
         public event PropertyChangedEventHandler PropertyChanged;
 
-        private void NotifyPropertyChanged(string info)
+        private void NotifyPropertyChanged([CallerMemberName] string propertyName = "")
         {
-            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(info));
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
         }
     }
 }

--- a/Files UWP/Interacts/RibbonActions/Layout.cs
+++ b/Files UWP/Interacts/RibbonActions/Layout.cs
@@ -1,4 +1,5 @@
 ﻿using System.ComponentModel;
+using System.Runtime.CompilerServices;
 
 namespace Files.Interacts.Layout
 {
@@ -23,9 +24,9 @@ namespace Files.Interacts.Layout
         }
         public event PropertyChangedEventHandler PropertyChanged;
 
-        private void NotifyPropertyChanged(string info)
+        private void NotifyPropertyChanged([CallerMemberName] string propertyName = "")
         {
-            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(info));
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
         }
     }
 }

--- a/Files UWP/Interacts/RibbonActions/Share.cs
+++ b/Files UWP/Interacts/RibbonActions/Share.cs
@@ -1,4 +1,5 @@
 ﻿using System.ComponentModel;
+using System.Runtime.CompilerServices;
 
 namespace Files.Interacts.Share
 {
@@ -23,9 +24,9 @@ namespace Files.Interacts.Share
         }
         public event PropertyChangedEventHandler PropertyChanged;
 
-        private void NotifyPropertyChanged(string info)
+        private void NotifyPropertyChanged([CallerMemberName] string propertyName = "")
         {
-            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(info));
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
         }
     }
 }

--- a/Files UWP/LoadingIndicator.cs
+++ b/Files UWP/LoadingIndicator.cs
@@ -1,4 +1,5 @@
 ﻿using System.ComponentModel;
+using System.Runtime.CompilerServices;
 using Windows.UI.Xaml;
 
 namespace Files.Filesystem
@@ -24,9 +25,9 @@ namespace Files.Filesystem
         }
         public event PropertyChangedEventHandler PropertyChanged;
 
-        private void NotifyPropertyChanged(string info)
+        private void NotifyPropertyChanged([CallerMemberName] string propertyName = "")
         {
-            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(info));
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
         }
     }
 }

--- a/Files UWP/Navigation/BackState.cs
+++ b/Files UWP/Navigation/BackState.cs
@@ -1,4 +1,5 @@
 ﻿using System.ComponentModel;
+using System.Runtime.CompilerServices;
 
 namespace Files.Navigation
 {
@@ -22,10 +23,10 @@ namespace Files.Navigation
         }
         
         public event PropertyChangedEventHandler PropertyChanged;
-        
-        private void NotifyPropertyChanged(string info)
+
+        private void NotifyPropertyChanged([CallerMemberName] string propertyName = "")
         {
-            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(info));
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
         }
     }
 }

--- a/Files UWP/Navigation/ForwardState.cs
+++ b/Files UWP/Navigation/ForwardState.cs
@@ -1,4 +1,5 @@
 ﻿using System.ComponentModel;
+using System.Runtime.CompilerServices;
 
 namespace Files.Navigation
 {
@@ -22,9 +23,9 @@ namespace Files.Navigation
         }
         public event PropertyChangedEventHandler PropertyChanged;
 
-        private void NotifyPropertyChanged(string info)
+        private void NotifyPropertyChanged([CallerMemberName] string propertyName = "")
         {
-            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(info));
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
         }
     }
 }

--- a/Files UWP/Navigation/UniversalPath.cs
+++ b/Files UWP/Navigation/UniversalPath.cs
@@ -1,4 +1,5 @@
 ﻿using System.ComponentModel;
+using System.Runtime.CompilerServices;
 
 namespace Files.Navigation
 {
@@ -25,11 +26,10 @@ namespace Files.Navigation
         }
         public event PropertyChangedEventHandler PropertyChanged;
 
-        private void NotifyPropertyChanged(string info)
+        private void NotifyPropertyChanged([CallerMemberName] string propertyName = "")
         {
-            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(info));
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
         }
-
     }
 
     public class DisplayedPathText : INotifyPropertyChanged
@@ -53,10 +53,9 @@ namespace Files.Navigation
         }
         public event PropertyChangedEventHandler PropertyChanged;
 
-        private void NotifyPropertyChanged(string info)
+        private void NotifyPropertyChanged([CallerMemberName] string propertyName = "")
         {
-            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(info));
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
         }
-
     }
 }

--- a/Files UWP/PhotoAlbum.xaml
+++ b/Files UWP/PhotoAlbum.xaml
@@ -388,13 +388,13 @@
                         <MenuFlyoutSubItem.Icon>
                             <FontIcon Glyph="&#xE8CB;"/>
                         </MenuFlyoutSubItem.Icon>
-                        <uilib:RadioMenuFlyoutItem Text="Name" GroupName="SortGroup" IsChecked="{x:Bind IsSortedByName, Mode=TwoWay}"/>
-                        <uilib:RadioMenuFlyoutItem Text="Date modified" GroupName="SortGroup" IsChecked="{x:Bind IsSortedByDate, Mode=TwoWay}"/>
-                        <uilib:RadioMenuFlyoutItem Text="Type" GroupName="SortGroup" IsChecked="{x:Bind IsSortedByType, Mode=TwoWay}"/>
-                        <uilib:RadioMenuFlyoutItem Text="Size" GroupName="SortGroup" IsChecked="{x:Bind IsSortedBySize, Mode=TwoWay}"/>
+                        <uilib:RadioMenuFlyoutItem Text="Name" GroupName="SortGroup" IsChecked="{x:Bind viewModelInstance.IsSortedByName, Mode=TwoWay}"/>
+                        <uilib:RadioMenuFlyoutItem Text="Date modified" GroupName="SortGroup" IsChecked="{x:Bind viewModelInstance.IsSortedByDate, Mode=TwoWay}"/>
+                        <uilib:RadioMenuFlyoutItem Text="Type" GroupName="SortGroup" IsChecked="{x:Bind viewModelInstance.IsSortedByType, Mode=TwoWay}"/>
+                        <uilib:RadioMenuFlyoutItem Text="Size" GroupName="SortGroup" IsChecked="{x:Bind viewModelInstance.IsSortedBySize, Mode=TwoWay}"/>
                         <MenuFlyoutSeparator/>
-                        <uilib:RadioMenuFlyoutItem Text="Ascending" GroupName="SortOrderGroup" IsChecked="{x:Bind IsSortedAscending, Mode=TwoWay}"/>
-                        <uilib:RadioMenuFlyoutItem Text="Descending" GroupName="SortOrderGroup" IsChecked="{x:Bind IsSortedDescending, Mode=TwoWay}"/>
+                        <uilib:RadioMenuFlyoutItem Text="Ascending" GroupName="SortOrderGroup" IsChecked="{x:Bind viewModelInstance.IsSortedAscending, Mode=TwoWay}"/>
+                        <uilib:RadioMenuFlyoutItem Text="Descending" GroupName="SortOrderGroup" IsChecked="{x:Bind viewModelInstance.IsSortedDescending, Mode=TwoWay}"/>
                     </MenuFlyoutSubItem>
                     <MenuFlyoutItem Click="RefreshGrid_Click" Text="Refresh" Name="RefreshGrid">
                         <MenuFlyoutItem.Icon>

--- a/Files UWP/PhotoAlbum.xaml.cs
+++ b/Files UWP/PhotoAlbum.xaml.cs
@@ -46,35 +46,6 @@ namespace Files
         ProHome tabInstance;
         public EmptyFolderTextState TextState { get; set; } = new EmptyFolderTextState();
 
-        private bool IsSortedByName { get { return viewModelInstance.DirectorySortOption == SortOption.Name; } set { if (value) viewModelInstance.DirectorySortOption = SortOption.Name; } }
-        private bool IsSortedByDate { get { return viewModelInstance.DirectorySortOption == SortOption.DateModified; } set { if (value) viewModelInstance.DirectorySortOption = SortOption.DateModified; } }
-        private bool IsSortedByType { get { return viewModelInstance.DirectorySortOption == SortOption.FileType; } set { if (value) viewModelInstance.DirectorySortOption = SortOption.FileType; } }
-        private bool IsSortedBySize { get { return viewModelInstance.DirectorySortOption == SortOption.Size; } set { if (value) viewModelInstance.DirectorySortOption = SortOption.Size; } }
-        
-        private bool IsSortedAscending
-        {
-            get
-            {
-                return viewModelInstance.DirectorySortDirection == SortDirection.Ascending;
-            }
-            set
-            {
-                viewModelInstance.DirectorySortDirection = value ? SortDirection.Ascending : SortDirection.Descending;
-            }
-        }
-
-        private bool IsSortedDescending
-        {
-            get
-            {
-                return !IsSortedAscending;
-            }
-            set
-            {
-                IsSortedAscending = !value;
-            }
-        }
-
         public PhotoAlbum()
         {
             this.InitializeComponent();
@@ -202,7 +173,6 @@ namespace Files
             }
 
         }
-
 
         private void FileList_Tapped(object sender, Windows.UI.Xaml.Input.TappedRoutedEventArgs e)
         {

--- a/Files UWP/ProHome.xaml
+++ b/Files UWP/ProHome.xaml
@@ -691,7 +691,20 @@
                                         </AppBarButton.KeyboardAccelerators>
                                     </AppBarButton>
                                     <AppBarButton Click="ClearAllButton_Click" Name="ClearAllButton" IsEnabled="{x:Bind LayoutItems.isEnabled, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Icon="ClearSelection" Label="Clear All"/>
-
+                                    <AppBarSeparator/>
+                                    <AppBarButton IsEnabled="{x:Bind LayoutItems.isEnabled, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Icon="Sort" Label="Sort by">
+                                        <AppBarButton.Flyout>
+                                            <MenuFlyout Placement="BottomEdgeAlignedLeft">
+                                                <uilib:RadioMenuFlyoutItem Text="Name" GroupName="SortGroup" IsChecked="{x:Bind instanceViewModel.IsSortedByName, Mode=TwoWay}"/>
+                                                <uilib:RadioMenuFlyoutItem Text="Date modified" GroupName="SortGroup" IsChecked="{x:Bind instanceViewModel.IsSortedByDate, Mode=TwoWay}"/>
+                                                <uilib:RadioMenuFlyoutItem Text="Type" GroupName="SortGroup" IsChecked="{x:Bind instanceViewModel.IsSortedByType, Mode=TwoWay}"/>
+                                                <uilib:RadioMenuFlyoutItem Text="Size" GroupName="SortGroup" IsChecked="{x:Bind instanceViewModel.IsSortedBySize, Mode=TwoWay}"/>
+                                                <MenuFlyoutSeparator/>
+                                                <uilib:RadioMenuFlyoutItem Text="Ascending" GroupName="SortOrderGroup" IsChecked="{x:Bind instanceViewModel.IsSortedAscending, Mode=TwoWay}"/>
+                                                <uilib:RadioMenuFlyoutItem Text="Descending" GroupName="SortOrderGroup" IsChecked="{x:Bind instanceViewModel.IsSortedDescending, Mode=TwoWay}"/>
+                                            </MenuFlyout>
+                                        </AppBarButton.Flyout>
+                                    </AppBarButton>
                                 </CommandBar>
                             </CommandBar.Content>
                         </CommandBar>

--- a/Files UWP/ProHome.xaml.cs
+++ b/Files UWP/ProHome.xaml.cs
@@ -3,7 +3,6 @@ using Files.Filesystem;
 using Files.Interacts;
 using Files.Navigation;
 using Microsoft.UI.Xaml.Controls;
-using Microsoft.UI.Xaml.Controls.Primitives;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -23,9 +22,6 @@ using Windows.UI.Xaml.Navigation;
 
 namespace Files
 {
-    /// <summary>
-    /// Code to accompany Project Mumbai layout
-    /// </summary>
     public sealed partial class ProHome : Page
     {
         public ListView locationsList;
@@ -66,8 +62,21 @@ namespace Files
         public ConsentDialog consentDialog = new ConsentDialog();
         public ListView accessiblePathListView;
         public ObservableCollection<PathBoxItem> pathBoxItems = new ObservableCollection<PathBoxItem>();
-        public ItemViewModel instanceViewModel;
+        private ItemViewModel _instanceViewModel;
         public Interaction instanceInteraction;
+
+        public ItemViewModel instanceViewModel
+        {
+            get
+            {
+                return _instanceViewModel;
+            }
+            set
+            {
+                _instanceViewModel = value;
+                Bindings.Update();
+            }
+        }
 
         public ProHome()
         {
@@ -1057,6 +1066,7 @@ namespace Files
             VisiblePath.SelectionStart = VisiblePath.Text.Length;
         }
     }
+
     public class NavigationActions
     {
         public async static void Refresh_Click(object sender, RoutedEventArgs e)

--- a/Files UWP/SettingsPages/Personalization.xaml.cs
+++ b/Files UWP/SettingsPages/Personalization.xaml.cs
@@ -3,6 +3,7 @@ using Microsoft.Toolkit.Uwp.UI.Animations;
 using System;
 using System.ComponentModel;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 
@@ -81,9 +82,9 @@ namespace Files.SettingsPages
         }
 
         public event PropertyChangedEventHandler PropertyChanged;
-        private void NotifyPropertyChanged(string info)
+        private void NotifyPropertyChanged([CallerMemberName] string propertyName = "")
         {
-            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(info));
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
         }
     }
 }

--- a/Files UWP/YourHome.xaml.cs
+++ b/Files UWP/YourHome.xaml.cs
@@ -19,6 +19,7 @@ using Windows.UI.Text;
 using System.Threading.Tasks;
 using Windows.UI;
 using System.Windows.Input;
+using System.Runtime.CompilerServices;
 
 namespace Files
 {
@@ -553,9 +554,9 @@ namespace Files
             }
         }
         public event PropertyChangedEventHandler PropertyChanged;
-        private void NotifyPropertyChanged(string info)
+        private void NotifyPropertyChanged([CallerMemberName] string propertyName = "")
         {
-            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(info));
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
         }
     }
 }


### PR DESCRIPTION
This commit **completes the implementation of sorting in Files** by adding a "Sort by" button to the ribbon.
![image](https://user-images.githubusercontent.com/8487294/67867642-adf08300-fb65-11e9-8923-c4b65625d124.png)

#### Other changes
- Moves all sorting-related properties (e.g. `IsSortedByName`) to `ItemViewModel` from `GenericFileBrowser` and `PhotoAlbum`
- Refactors all instances of `NotifyPropertyChanged` to use the `CallerMemberName` attribute
- Removes some unused namespace references

# Related issues
#20 