### PR TITLE
Fix double-highlight on PhotoAlbum selection change

### DIFF
--- a/Files UWP/PhotoAlbum.xaml
+++ b/Files UWP/PhotoAlbum.xaml
@@ -523,6 +523,7 @@
                             </MenuFlyout>
                         </Setter.Value>
                     </Setter>
+                    <Setter Property="FocusVisualPrimaryBrush" Value="Transparent"/>
                 </Style>
             </GridView.ItemContainerStyle>
             <GridView.ItemTemplate>


### PR DESCRIPTION
Currently, changing the selection in PhotoAlbum using arrow keys causes a double-highlight to appear on the newly selected item.

This PR fixes this.

| Before | After |
| ---| --|
| ![image](https://user-images.githubusercontent.com/8487294/68070318-e1baeb00-fda7-11e9-8a59-5d68260bfbb3.png) | ![image](https://user-images.githubusercontent.com/8487294/68070318-e1baeb00-fda7-11e9-8a59-5d68260bfbb3.png) |
| ![image](https://user-images.githubusercontent.com/8487294/68070323-e8e1f900-fda7-11e9-9535-927609fa9cab.png) | ![image](https://user-images.githubusercontent.com/8487294/68070293-a1f40380-fda7-11e9-9d12-539a952c894a.png) |

