### PR TITLE
Started work on open file location in recents view

### DIFF
--- a/Files UWP/YourHome.xaml
+++ b/Files UWP/YourHome.xaml
@@ -606,6 +606,8 @@
                                             <MenuFlyout MenuFlyoutPresenterStyle="{StaticResource MenuFlyoutFluentThemeResources}">
                                                 <MenuFlyoutItem Click="mfi_RemoveOneItem_Click" Icon="Remove" Text="Remove this item" x:Name="mfi_RemoveOneItem"/>
                                                 <MenuFlyoutItem Click="MenuFlyoutItem_Click" Icon="Delete" Text="Clear all items"/>
+                                                <MenuFlyoutItem Click="OpenFileLocation_Click" Icon="Folder" Text="Open file location"/>
+
                                             </MenuFlyout>
                                         </Grid.ContextFlyout>
                                         <Grid.ColumnDefinitions>

--- a/Files UWP/YourHome.xaml.cs
+++ b/Files UWP/YourHome.xaml.cs
@@ -508,6 +508,15 @@ namespace Files
             Empty.Visibility = Visibility.Visible;
         }
 
+        private void OpenFileLocation_Click(object sender, RoutedEventArgs e)
+        {
+            var fe = sender as MenuFlyoutItem;
+            var vm = fe.DataContext as RecentItem;
+            App.selectedTabInstance.accessibleContentFrame.Navigate(typeof(GenericFileBrowser), vm.path);
+
+        }
+
+
         private void DropShadowPanel_PointerPressed(object sender, Windows.UI.Xaml.Input.PointerRoutedEventArgs e)
         {
             (sender as DropShadowPanel).ShadowOpacity = 0.025;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/39923744/68091613-cb686a00-fe4f-11e9-825d-4d5a689cc123.png)

I got it set up to open the file location for folders, however I need help getting it to work for files.
In addition we need to handle if the item location was deleted and instead of trying to go to the non existent location and crashing it should tell the user the location no longer exists and ask if they want to remove the item from the list.
We also need to select the right location on the sidebar, for example if the location is in the `c` drive then that drive should be selected in the sidebar.