### PR TITLE
Choose Terminal Applications

### DIFF
--- a/Files/App.xaml.cs
+++ b/Files/App.xaml.cs
@@ -98,8 +98,6 @@ namespace Files
 
         private async void LoadTerminalApps()
         {
-            ApplicationData.Current.LocalSettings.Values["terminal_id"] = 1;
-
             var localFolder = ApplicationData.Current.LocalFolder;
             var localSettingsFolder = await localFolder.CreateFolderAsync("settings", CreationCollisionOption.OpenIfExists);
             StorageFile file;

--- a/Files/App.xaml.cs
+++ b/Files/App.xaml.cs
@@ -30,6 +30,11 @@ using Windows.Management.Deployment;
 using Windows.Storage.Streams;
 using Windows.System;
 using Microsoft.UI.Xaml.Controls;
+using System.Threading.Tasks;
+using Windows.ApplicationModel.AppService;
+using Windows.ApplicationModel.AppExtensions;
+using Files.DataModels;
+using Newtonsoft.Json;
 
 namespace Files
 {
@@ -52,9 +57,9 @@ namespace Files
             }
             set
             {
-                if(value != occupiedInstance)
+                if (value != occupiedInstance)
                 {
-                    occupiedInstance = value; 
+                    occupiedInstance = value;
                 }
             }
         }
@@ -68,6 +73,7 @@ namespace Files
         public static ObservableCollection<WSLDistroItem> linuxDistroItems = new ObservableCollection<WSLDistroItem>();
         public static FormFactorMode FormFactor { get; set; } = FormFactorMode.Regular;
         ApplicationDataContainer localSettings;
+        public static IList<TerminalModel> Terminals {get; set;}
 
         public App()
         {
@@ -87,6 +93,33 @@ namespace Files
             PopulatePinnedSidebarItems();
             DetectWSLDistros();
             QuickLookIntegration();
+            LoadTerminalApps();
+        }
+
+        private async void LoadTerminalApps()
+        {
+            ApplicationData.Current.LocalSettings.Values["terminal_id"] = 1;
+
+            var localFolder = ApplicationData.Current.LocalFolder;
+            var localSettingsFolder = await localFolder.CreateFolderAsync("settings", CreationCollisionOption.OpenIfExists);
+            StorageFile file;
+            try
+            {
+                file = await localSettingsFolder.GetFileAsync("terminal.json");
+            }
+            catch (FileNotFoundException ex)
+            {
+                var defaultFile = StorageFile.GetFileFromApplicationUriAsync(new Uri("ms-appx:///Assets/terminal/terminal.json"));
+
+                file = await localSettingsFolder.CreateFileAsync("terminal.json");
+                await FileIO.WriteBufferAsync(file, await FileIO.ReadBufferAsync(await defaultFile));
+            }
+
+            var content = await FileIO.ReadTextAsync(file);
+
+            var terminals = JsonConvert.DeserializeObject<TerminalFileModel>(content).Terminals;
+
+            Terminals = terminals;
         }
 
         public void CloseOpenPopups()

--- a/Files/Assets/terminal/terminal.json
+++ b/Files/Assets/terminal/terminal.json
@@ -1,0 +1,21 @@
+﻿{
+  "version": 1,
+  "terminals": [
+    {
+      "id": 1,
+      "name": "CMD",
+      "path": "cmd.exe",
+      "arguments": "/k \"cd /d {0} && title Command Prompt\"",
+      "icon": "C:\\Users\\felix\\Pictures\\BingImageOfTheDay_20190730.jpg"
+    }
+    /*
+    {
+      "id": 2,
+      "name": "PowerShell Core 6",
+      "path": "pwsh.exe",
+      "arguments": "-WorkingDirectory {0}",
+      "icon": "C:\\Users\\felix\\Pictures\\BingImageOfTheDay_20190730.jpg"
+    }
+    */
+  ]
+}

--- a/Files/DataModels/TerminalFileModel.cs
+++ b/Files/DataModels/TerminalFileModel.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Files.DataModels
+{
+	class TerminalFileModel
+	{
+		public int Version { get; set; }
+
+		public List<TerminalModel> Terminals { get; set; }
+	}
+}

--- a/Files/DataModels/TerminalModel.cs
+++ b/Files/DataModels/TerminalModel.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Files.DataModels
+{
+	public class TerminalModel
+	{
+		public int Id { get; set; }
+
+		public string Name { get; set; }
+
+		public string Path { get; set; }
+
+		public string icon { get; set; }
+
+		public string arguments { get; set; }
+	}
+}

--- a/Files/Files.csproj
+++ b/Files/Files.csproj
@@ -145,6 +145,8 @@
     <Compile Include="Controls\RibbonPage.xaml.cs">
       <DependentUpon>RibbonPage.xaml</DependentUpon>
     </Compile>
+    <Compile Include="DataModels\TerminalFileModel.cs" />
+    <Compile Include="DataModels\TerminalModel.cs" />
     <Compile Include="Dialogs\AddItemDialog.xaml.cs">
       <DependentUpon>AddItemDialog.xaml</DependentUpon>
     </Compile>
@@ -232,6 +234,9 @@
     <Content Include="Assets\FilesHome.png" />
     <Content Include="Assets\FilesDrive.png" />
     <Content Include="Assets\logo.bmp" />
+    <None Include="Assets\terminal\terminal.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Include="Package.StoreAssociation.xml" />
     <Content Include="Assets\QuickLook\quicklook_icon_black.png" />
     <Content Include="Assets\StoreLogo.png" />
@@ -383,6 +388,9 @@
     </PackageReference>
     <PackageReference Include="MvvmLight">
       <Version>5.4.1.1</Version>
+    </PackageReference>
+    <PackageReference Include="Newtonsoft.Json">
+      <Version>12.0.3</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/Files/Interacts/Interaction.cs
+++ b/Files/Interacts/Interaction.cs
@@ -94,7 +94,11 @@ namespace Files.Interacts
         public async void OpenDirectoryInTerminal(object sender, RoutedEventArgs e)
         {
             var localSettings = ApplicationData.Current.LocalSettings;
-            var terminalId = (int)localSettings.Values["terminal_id"];
+
+            var terminalId = 1;
+
+            if (localSettings.Values["terminal_id"] != null) terminalId = (int)localSettings.Values["terminal_id"];
+
             var terminal = App.Terminals.Single(p => p.Id == terminalId);
 
             localSettings.Values["Application"] = terminal.Path;

--- a/Files/Interacts/Interaction.cs
+++ b/Files/Interacts/Interaction.cs
@@ -93,16 +93,12 @@ namespace Files.Interacts
 
         public async void OpenDirectoryInTerminal(object sender, RoutedEventArgs e)
         {
+            var localSettings = ApplicationData.Current.LocalSettings;
+            var terminalId = (int)localSettings.Values["terminal_id"];
+            var terminal = App.Terminals.Single(p => p.Id == terminalId);
 
-            ApplicationData.Current.LocalSettings.Values["Application"] = "cmd.exe";
-            if(App.OccupiedInstance.ItemDisplayFrame.SourcePageType == typeof(GenericFileBrowser))
-            {
-                ApplicationData.Current.LocalSettings.Values["Arguments"] = "/k \"cd /d "+ currentInstance.instanceViewModel.Universal.path + "&& title Command Prompt" + "\""; 
-            }
-            else if(App.OccupiedInstance.ItemDisplayFrame.SourcePageType == typeof(PhotoAlbum))
-            {
-                ApplicationData.Current.LocalSettings.Values["Arguments"] = "/k \"cd /d " + currentInstance.instanceViewModel.Universal.path + "&& title Command Prompt" + "\"";
-            }
+            localSettings.Values["Application"] = terminal.Path;
+            localSettings.Values["Arguments"] = String.Format(terminal.arguments, currentInstance.instanceViewModel.Universal.path);
 
             await FullTrustProcessLauncher.LaunchFullTrustProcessForCurrentAppAsync();
         }

--- a/Files/SettingsPages/Preferences.xaml
+++ b/Files/SettingsPages/Preferences.xaml
@@ -59,8 +59,9 @@
                         <TextBlock FontSize="20" Text="Terminal Applications"/>
                         
                         <ComboBox
-                        Header="Choose Terminal Application"
-                        ItemsSource="{x:Bind Terminals}"
+                            x:Name="TerminalApplicationsComboBox"
+                            Header="Choose Terminal Application"
+                            ItemsSource="{x:Bind Terminals}"
                             SelectionChanged="TerminalApp_SelectionChanged">
                             <ComboBox.ItemTemplate>
                                 <DataTemplate x:DataType="datamodels:TerminalModel">

--- a/Files/SettingsPages/Preferences.xaml
+++ b/Files/SettingsPages/Preferences.xaml
@@ -4,7 +4,7 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:local="using:Files.SettingsPages"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" xmlns:datamodels="using:Files.DataModels"
     mc:Ignorable="d"
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 
@@ -51,6 +51,26 @@
                                 <TextBlock VerticalAlignment="Center" Text="Restart the app for these changes to take effect."/>
                             </StackPanel>
                         </StackPanel>
+                    </StackPanel>
+                </Grid>
+
+                <Grid Margin="0,18,0,0">
+                    <StackPanel Orientation="Vertical">
+                        <TextBlock FontSize="20" Text="Terminal Applications"/>
+                        
+                        <ComboBox
+                        Header="Choose Terminal Application"
+                        ItemsSource="{x:Bind Terminals}"
+                            SelectionChanged="TerminalApp_SelectionChanged">
+                            <ComboBox.ItemTemplate>
+                                <DataTemplate x:DataType="datamodels:TerminalModel">
+                                    <StackPanel Orientation="Horizontal">
+                                        <TextBlock Text="{x:Bind Name}"/>
+                                    </StackPanel>
+                                </DataTemplate>
+                            </ComboBox.ItemTemplate>
+                        </ComboBox>
+                        <HyperlinkButton Content="Edit Terminal Applications" Click="EditTerminalApplications_Click"/>
                     </StackPanel>
                 </Grid>
             </StackPanel>

--- a/Files/SettingsPages/Preferences.xaml.cs
+++ b/Files/SettingsPages/Preferences.xaml.cs
@@ -9,6 +9,8 @@ using Newtonsoft.Json;
 using Files.DataModels;
 using System.Collections.ObjectModel;
 using Windows.System;
+using Windows.UI.Xaml.Navigation;
+using System.Linq;
 
 namespace Files.SettingsPages
 {
@@ -78,31 +80,20 @@ namespace Files.SettingsPages
                 OneDriveL.IsEnabled = false;
             }
             SuccessMark.Visibility = Windows.UI.Xaml.Visibility.Collapsed;
-
-            LoadTerminalsAsync();
         }
 
-        private async System.Threading.Tasks.Task LoadTerminalsAsync()
+        protected override void OnNavigatedTo(NavigationEventArgs e)
         {
-            var localSettingsFolder = await localFolder.CreateFolderAsync("settings", CreationCollisionOption.OpenIfExists);
-            StorageFile file;
-            try
-            {
-                file = await localSettingsFolder.GetFileAsync("terminal.json");
-            }
-            catch (FileNotFoundException ex)
-            {
-                var defaultFile = StorageFile.GetFileFromApplicationUriAsync(new Uri("ms-appx:///Assets/terminal/terminal.json"));
+            base.OnNavigatedTo(e);
 
-                file = await localSettingsFolder.CreateFileAsync("terminal.json");
-                await FileIO.WriteBufferAsync(file, await FileIO.ReadBufferAsync(await defaultFile));
-            }
-                        
-            var content = await FileIO.ReadTextAsync(file);
-
-            var terminals = JsonConvert.DeserializeObject<TerminalFileModel>(content).Terminals;
+            var terminals = App.Terminals;
 
             foreach (var terminal in terminals) Terminals.Add(terminal);
+
+            var terminalId = 1;
+            if (localSettings.Values["terminal_id"] != null) terminalId = (int) localSettings.Values["terminal_id"];
+
+            TerminalApplicationsComboBox.SelectedItem = Terminals.Single(p => p.Id == terminalId);
         }
 
         private void ToggleSwitch_Toggled(object sender, Windows.UI.Xaml.RoutedEventArgs e)


### PR DESCRIPTION
# Description

- Creates a `terminals.json` in the "local"-AppFolder with terminal profiles ([file](https://github.com/lampenlampen/files-uwp/blob/feat/Terminal/Files/Assets/terminal/terminal.json)). As default profile the "cmd"-profile is included. A second commented profile for powershell is also included. It seems the new Windows Terminal currently does not support launching in a specific directory from commandline ([link](https://github.com/microsoft/terminal/pull/4023#issue-355223599)).
- Includes a combobox in the settings to choose between the profiles.

# UI

Light | Dark
------------ | -------------
![files_terminal_settings_white](https://user-images.githubusercontent.com/26199386/71624532-557c4700-2be3-11ea-938a-699efffe7a6f.png) | ![files_terminal_settings_dark](https://user-images.githubusercontent.com/26199386/71624539-5c0abe80-2be3-11ea-9700-85bc27535175.png)

# Question

1. [JSON.Net](https://www.newtonsoft.com/json) as dependency?
2. `terminal.json`-schema? At the moment you can specify a name, a description, the executable path, arguments and an icon, but only the name, the path and the arguments are used.