### PR TITLE
Extend view into titlebar of properties window

### DIFF
--- a/Files/Interacts/Interaction.cs
+++ b/Files/Interacts/Interaction.cs
@@ -444,6 +444,11 @@ namespace Files.Interacts
             if (ApiInformation.IsApiContractPresent("Windows.Foundation.UniversalApiContract", 8))
             {
                 AppWindow appWindow = await AppWindow.TryCreateAsync();
+                appWindow.TitleBar.ExtendsContentIntoTitleBar = true;
+                var titleBar = appWindow.TitleBar;
+                titleBar.ButtonBackgroundColor = Colors.Transparent;
+                titleBar.ButtonInactiveBackgroundColor = Colors.Transparent;
+
                 Frame frame = new Frame();
                 frame.Navigate(typeof(Properties), null, new SuppressNavigationTransitionInfo());
                 WindowManagementPreview.SetPreferredMinSize(appWindow, new Size(400, 475));

--- a/Files/Properties.xaml
+++ b/Files/Properties.xaml
@@ -16,7 +16,7 @@
             <RowDefinition Height="*"/>
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
-        <StackPanel Padding="22,14" Spacing="14" Grid.Row="0" Orientation="Horizontal">
+        <StackPanel Padding="22, 48,14, 48" Spacing="14" Grid.Row="0" Orientation="Horizontal">
 
             <Grid
                     x:Name="Icon"
@@ -59,7 +59,7 @@
                     IsReadOnly="True"
                     Text="{x:Bind ItemProperties.ItemName,Mode=OneWay}" Width="300" />
         </StackPanel>
-        <StackPanel Padding="14,0" Grid.Row="1">
+        <StackPanel Padding="14, 32,0, 0" Grid.Row="1">
             <MenuFlyoutSeparator Margin="-14,0" HorizontalAlignment="Stretch" />
             <Grid Padding="0,4">
                 <Grid.ColumnDefinitions>


### PR DESCRIPTION
I made a change to extend the view into the titlebar of the properties window and added some spacing around the header.

![files_properties_titlebar_light](https://user-images.githubusercontent.com/26199386/78786567-3f7fde80-79a9-11ea-8525-a180fa94f048.png)

I orientated myself by this [concept](https://i.redd.it/jqmrzvwc7pj41.png).