### PR TITLE
Fixed terminals json deserialization during second app start

### DIFF
--- a/Files/View Models/SettingsViewModel.cs
+++ b/Files/View Models/SettingsViewModel.cs
@@ -322,7 +322,7 @@ namespace Files.View_Models
                         Id = terminalsFileModel.Terminals.Count + 1,
                         Name = "Windows Terminal",
                         Path = "wt.exe",
-                        arguments = "-d \"{0}\"",
+                        arguments = "-d {0}",
                         icon = ""
                     });
                     await FileIO.WriteTextAsync(file, JsonConvert.SerializeObject(terminalsFileModel, Formatting.Indented));

--- a/Files/View Models/SettingsViewModel.cs
+++ b/Files/View Models/SettingsViewModel.cs
@@ -308,29 +308,27 @@ namespace Files.View_Models
 
             var content = await FileIO.ReadTextAsync(file);
 
-            var terminals = JsonConvert.DeserializeObject<TerminalFileModel>(content).Terminals;
-
-            Terminals = terminals;
+            var terminalsFileModel = JsonConvert.DeserializeObject<TerminalFileModel>(content);
 
             // Ensure Windows Terminal is not already in List
-            if (Terminals.FirstOrDefault(x => x.Path.Equals("wt.exe", StringComparison.OrdinalIgnoreCase)) == null)
+            if (terminalsFileModel.Terminals.FirstOrDefault(x => x.Path.Equals("wt.exe", StringComparison.OrdinalIgnoreCase)) == null)
             {
                 PackageManager packageManager = new PackageManager();
                 var terminalPackage = packageManager.FindPackagesForUser(string.Empty, "Microsoft.WindowsTerminal_8wekyb3d8bbwe");
                 if (terminalPackage != null)
                 {
-                    terminals.Add(new TerminalModel()
+                    terminalsFileModel.Terminals.Add(new TerminalModel()
                     {
-                        Id = terminals.Count + 1,
+                        Id = terminalsFileModel.Terminals.Count + 1,
                         Name = "Windows Terminal",
                         Path = "wt.exe",
                         arguments = "-d \"{0}\"",
                         icon = ""
                     });
-                    await FileIO.WriteTextAsync(file, JsonConvert.SerializeObject(terminals, Formatting.Indented));
-                    Terminals = terminals;
+                    await FileIO.WriteTextAsync(file, JsonConvert.SerializeObject(terminalsFileModel, Formatting.Indented));
                 }
             }
+            Terminals = terminalsFileModel.Terminals;
         }
 
         private IList<TerminalModel> _Terminals = null;


### PR DESCRIPTION
After first install and start app it working fine, but during second start it crashed. Reason is different models of terminals.json in Assets folder and serialized json(after checking for wt.exe in 4e5f739003bb1ee6aaeb32f85b88caae9f9ea96f)