### PR TITLE
Sort filenames naturally using CompareStringEx

### DIFF
--- a/Files/Files.csproj
+++ b/Files/Files.csproj
@@ -150,6 +150,7 @@
       <DependentUpon>ConfirmDeleteDialog.xaml</DependentUpon>
     </Compile>
     <Compile Include="Helpers\ItemsDataTemplateSelector.cs" />
+    <Compile Include="Helpers\NaturalStringComparer.cs" />
     <Compile Include="UserControls\NavigationToolbar\INavigationToolbar.cs" />
     <Compile Include="UserControls\NavigationToolbar\ModernNavigationToolbar.xaml.cs">
       <DependentUpon>ModernNavigationToolbar.xaml</DependentUpon>

--- a/Files/Helpers/NaturalStringComparer.cs
+++ b/Files/Helpers/NaturalStringComparer.cs
@@ -1,19 +1,54 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Runtime.InteropServices;
 
 namespace Files.Helpers
 {
     internal static class SafeNativeMethods
     {
-        [DllImport("shlwapi.dll", CharSet = CharSet.Unicode)]
-        public static extern int StrCmpLogicalW(string psz1, string psz2);
+        public static readonly Int32 NORM_IGNORECASE = 0x00000001;
+        public static readonly Int32 NORM_IGNORENONSPACE = 0x00000002;
+        public static readonly Int32 NORM_IGNORESYMBOLS = 0x00000004;
+        public static readonly Int32 LINGUISTIC_IGNORECASE = 0x00000010;
+        public static readonly Int32 LINGUISTIC_IGNOREDIACRITIC = 0x00000020;
+        public static readonly Int32 NORM_IGNOREKANATYPE = 0x00010000;
+        public static readonly Int32 NORM_IGNOREWIDTH = 0x00020000;
+        public static readonly Int32 NORM_LINGUISTIC_CASING = 0x08000000;
+        public static readonly Int32 SORT_STRINGSORT = 0x00001000;
+        public static readonly Int32 SORT_DIGITSASNUMBERS = 0x00000008;
+
+        public static readonly String LOCALE_NAME_USER_DEFAULT = null;
+        public static readonly String LOCALE_NAME_INVARIANT = String.Empty;
+        public static readonly String LOCALE_NAME_SYSTEM_DEFAULT = "!sys-default-locale";
+
+        [DllImport("api-ms-win-core-string-l1-1-0 .dll", CharSet = CharSet.Unicode)]
+        public static extern Int32 CompareStringEx(
+          String localeName,
+          Int32 flags,
+          String str1,
+          Int32 count1,
+          String str2,
+          Int32 count2,
+          IntPtr versionInformation,
+          IntPtr reserved,
+          Int32 param
+        );
     }
 
     public class NaturalStringComparer : IComparer<object>
     {
         public int Compare(object a, object b)
         {
-            return SafeNativeMethods.StrCmpLogicalW(a.ToString(), b.ToString());
+            return SafeNativeMethods.CompareStringEx(
+              SafeNativeMethods.LOCALE_NAME_USER_DEFAULT,
+              SafeNativeMethods.SORT_DIGITSASNUMBERS, // Add other flags if required.
+              a.ToString(),
+              a.ToString().Length,
+              b.ToString(),
+              b.ToString().Length,
+              IntPtr.Zero,
+              IntPtr.Zero,
+              0) - 2;
         }
     }
 }

--- a/Files/Helpers/NaturalStringComparer.cs
+++ b/Files/Helpers/NaturalStringComparer.cs
@@ -1,0 +1,19 @@
+﻿using System.Collections.Generic;
+using System.Runtime.InteropServices;
+
+namespace Files.Helpers
+{
+    internal static class SafeNativeMethods
+    {
+        [DllImport("shlwapi.dll", CharSet = CharSet.Unicode)]
+        public static extern int StrCmpLogicalW(string psz1, string psz2);
+    }
+
+    public class NaturalStringComparer : IComparer<object>
+    {
+        public int Compare(object a, object b)
+        {
+            return SafeNativeMethods.StrCmpLogicalW(a.ToString(), b.ToString());
+        }
+    }
+}

--- a/Files/View Models/ItemViewModel.cs
+++ b/Files/View Models/ItemViewModel.cs
@@ -1,7 +1,7 @@
 ﻿using ByteSizeLib;
 using Files.Enums;
+using Files.Helpers;
 using Files.Interacts;
-using Files.View_Models;
 using Files.Views.Pages;
 using Microsoft.Toolkit.Uwp.UI;
 using Microsoft.UI.Xaml.Controls;
@@ -389,6 +389,7 @@ namespace Files.Filesystem
 
             static object orderByNameFunc(ListedItem item) => item.ItemName;
             Func<ListedItem, object> orderFunc = orderByNameFunc;
+            NaturalStringComparer naturalStringComparer = new NaturalStringComparer();
             switch (DirectorySortOption)
             {
                 case SortOption.Name:
@@ -412,22 +413,37 @@ namespace Files.Filesystem
             List<ListedItem> orderedList;
 
             if (DirectorySortDirection == SortDirection.Ascending)
-                ordered = _filesAndFolders.OrderBy(folderThenFileAsync).ThenBy(orderFunc);
+            {
+                if (DirectorySortOption == SortOption.Name)
+                    ordered = _filesAndFolders.OrderBy(folderThenFileAsync).ThenBy(orderFunc, naturalStringComparer);
+                else
+                    ordered = _filesAndFolders.OrderBy(folderThenFileAsync).ThenBy(orderFunc);
+            }
             else
             {
                 if (DirectorySortOption == SortOption.FileType)
-                    ordered = _filesAndFolders.OrderBy(folderThenFileAsync).ThenByDescending(orderFunc);
+                {
+                    if (DirectorySortOption == SortOption.Name)
+                        ordered = _filesAndFolders.OrderBy(folderThenFileAsync).ThenByDescending(orderFunc, naturalStringComparer);
+                    else
+                        ordered = _filesAndFolders.OrderBy(folderThenFileAsync).ThenByDescending(orderFunc);
+                }
                 else
-                    ordered = _filesAndFolders.OrderByDescending(folderThenFileAsync).ThenByDescending(orderFunc);
+                {
+                    if (DirectorySortOption == SortOption.Name)
+                        ordered = _filesAndFolders.OrderByDescending(folderThenFileAsync).ThenByDescending(orderFunc, naturalStringComparer);
+                    else
+                        ordered = _filesAndFolders.OrderByDescending(folderThenFileAsync).ThenByDescending(orderFunc);
+                }
             }
 
             // Further order by name if applicable
             if (DirectorySortOption != SortOption.Name)
             {
                 if (DirectorySortDirection == SortDirection.Ascending)
-                    ordered = ordered.ThenBy(orderByNameFunc);
+                    ordered = ordered.ThenBy(orderByNameFunc, naturalStringComparer);
                 else
-                    ordered = ordered.ThenByDescending(orderByNameFunc);
+                    ordered = ordered.ThenByDescending(orderByNameFunc, naturalStringComparer);
             }
             orderedList = ordered.ToList();
             _filesAndFolders.Clear();


### PR DESCRIPTION
Adds a `NaturalStringComparer` class which is used in `ItemViewModel` when sorting by file name.

![image](https://user-images.githubusercontent.com/8487294/79045498-0b711b80-7c3e-11ea-9fc3-004eacf9185f.png)

Resolves #352.