### PR TITLE
Improve tab behavior when in special folders

### DIFF
--- a/Files/Interacts/Interaction.cs
+++ b/Files/Interacts/Interaction.cs
@@ -346,13 +346,7 @@ namespace Files.Interacts
                         CurrentInstance.NavigationToolbar.PathControlDisplayText = selectedItemPath;
 
                         (CurrentInstance.ContentPage as BaseLayout).AssociatedViewModel.EmptyTextState.IsVisible = Visibility.Collapsed;
-                        App.CurrentInstance.SidebarSelectedItem = App.sideBarItems.FirstOrDefault(x => x.Path != null && x.Path.Equals(selectedItemPath, StringComparison.OrdinalIgnoreCase));
-                        if (App.CurrentInstance.SidebarSelectedItem == null)
-                        {
-                            App.CurrentInstance.SidebarSelectedItem = App.sideBarItems.FirstOrDefault(x => x.Path != null && x.Path.Equals(Path.GetPathRoot(selectedItemPath), StringComparison.OrdinalIgnoreCase));
-                        }
                         CurrentInstance.ContentFrame.Navigate(sourcePageType, selectedItemPath, new SuppressNavigationTransitionInfo());
-
                     }
                     else
                     {

--- a/Files/UserControls/ModernSidebar.xaml.cs
+++ b/Files/UserControls/ModernSidebar.xaml.cs
@@ -56,7 +56,7 @@ namespace Files.Controls
         {
             //(App.CurrentInstance.OperationsControl as RibbonArea).RibbonViewModel.HomeItems.isEnabled = false;
             //(App.CurrentInstance.OperationsControl as RibbonArea).RibbonViewModel.ShareItems.isEnabled = false;
-            string NaviagtionPath = ""; // path to navigate
+            string NavigationPath = ""; // path to navigate
 
             if (args.InvokedItem == null)
             {
@@ -77,21 +77,21 @@ namespace Files.Controls
                         }
                         else // Any other item
                         {
-                            NaviagtionPath = args.InvokedItemContainer.Tag.ToString();
+                            NavigationPath = args.InvokedItemContainer.Tag.ToString();
                         }
 
                         break;
                     }
                 case NavigationControlItemType.OneDrive:
                     {
-                        NaviagtionPath = App.AppSettings.OneDrivePath;
+                        NavigationPath = App.AppSettings.OneDrivePath;
                         break;
                     }
                 default:
                     {
                         var clickedItem = args.InvokedItemContainer;
 
-                        NaviagtionPath = clickedItem.Tag.ToString();
+                        NavigationPath = clickedItem.Tag.ToString();
 
                         App.CurrentInstance.NavigationToolbar.PathControlDisplayText = clickedItem.Tag.ToString();
                         //(App.CurrentInstance.OperationsControl as RibbonArea).RibbonViewModel.LayoutItems.isEnabled = true;
@@ -102,11 +102,11 @@ namespace Files.Controls
 
             if (App.AppSettings.LayoutMode == 0) // List View
             {
-                App.CurrentInstance.ContentFrame.Navigate(typeof(GenericFileBrowser), NaviagtionPath, new SuppressNavigationTransitionInfo());
+                App.CurrentInstance.ContentFrame.Navigate(typeof(GenericFileBrowser), NavigationPath, new SuppressNavigationTransitionInfo());
             }
             else
             {
-                App.CurrentInstance.ContentFrame.Navigate(typeof(PhotoAlbum), NaviagtionPath, new SuppressNavigationTransitionInfo());
+                App.CurrentInstance.ContentFrame.Navigate(typeof(PhotoAlbum), NavigationPath, new SuppressNavigationTransitionInfo());
             }
 
             App.CurrentInstance.NavigationToolbar.PathControlDisplayText = App.CurrentInstance.ViewModel.WorkingDirectory;

--- a/Files/UserControls/YourHome.xaml.cs
+++ b/Files/UserControls/YourHome.xaml.cs
@@ -96,29 +96,29 @@ namespace Files
 
         private void Button_Tapped(object sender, Windows.UI.Xaml.Input.TappedRoutedEventArgs e)
         {
-            string NaviagtionPath = ""; // path to navigate
+            string NavigationPath = ""; // path to navigate
             string ClickedCard = (sender as Button).Tag.ToString();
 
             switch (ClickedCard)
             {
                 case "Downloads":
-                    NaviagtionPath = App.AppSettings.DownloadsPath;
+                    NavigationPath = App.AppSettings.DownloadsPath;
                     break;
 
                 case "Documents":
-                    NaviagtionPath = App.AppSettings.DocumentsPath;
+                    NavigationPath = App.AppSettings.DocumentsPath;
                     break;
 
                 case "Pictures":
-                    NaviagtionPath = App.AppSettings.PicturesPath;
+                    NavigationPath = App.AppSettings.PicturesPath;
                     break;
 
                 case "Music":
-                    NaviagtionPath = App.AppSettings.MusicPath;
+                    NavigationPath = App.AppSettings.MusicPath;
                     break;
 
                 case ("Videos"):
-                    NaviagtionPath = App.AppSettings.VideosPath;
+                    NavigationPath = App.AppSettings.VideosPath;
                     break;
             }
 
@@ -126,10 +126,10 @@ namespace Files
             switch (App.AppSettings.LayoutMode)
             {
                 case 0:
-                    App.CurrentInstance.ContentFrame.Navigate(typeof(GenericFileBrowser), NaviagtionPath); // List View
+                    App.CurrentInstance.ContentFrame.Navigate(typeof(GenericFileBrowser), NavigationPath); // List View
                     break;
                 case 1:
-                    App.CurrentInstance.ContentFrame.Navigate(typeof(PhotoAlbum), NaviagtionPath); // Grid View
+                    App.CurrentInstance.ContentFrame.Navigate(typeof(PhotoAlbum), NavigationPath); // Grid View
                     break;
             }
         }

--- a/Files/View Models/ItemViewModel.cs
+++ b/Files/View Models/ItemViewModel.cs
@@ -54,7 +54,7 @@ namespace Files.Filesystem
                 {
                     _WorkingDirectory = value;
 
-                    App.CurrentInstance.SidebarSelectedItem = App.sideBarItems.FirstOrDefault(x => x.Path != null && x.Path.Equals(value.TrimEnd('\\'), StringComparison.OrdinalIgnoreCase));
+                    App.CurrentInstance.SidebarSelectedItem = App.sideBarItems.FirstOrDefault(x => x.Path != null && value.StartsWith(x.Path, StringComparison.OrdinalIgnoreCase));
                     if (App.CurrentInstance.SidebarSelectedItem == null)
                     {
                         App.CurrentInstance.SidebarSelectedItem = App.sideBarItems.FirstOrDefault(x => x.Path != null && x.Path.Equals(Path.GetPathRoot(value), StringComparison.OrdinalIgnoreCase));

--- a/Files/Views/InstanceTabsView.xaml.cs
+++ b/Files/Views/InstanceTabsView.xaml.cs
@@ -137,37 +137,37 @@ namespace Files
                         }
                     }
                 }
-                else if (path == App.AppSettings.DesktopPath)
+                else if (path.StartsWith(App.AppSettings.DesktopPath, StringComparison.OrdinalIgnoreCase))
                 {
                     tabLocationHeader = resourceLoader.GetString("SidebarDesktop");
                     fontIconSource.Glyph = "\xE8FC";
                 }
-                else if (path == App.AppSettings.DownloadsPath)
+                else if (path.StartsWith(App.AppSettings.DownloadsPath, StringComparison.OrdinalIgnoreCase))
                 {
                     tabLocationHeader = resourceLoader.GetString("SidebarDownloads");
                     fontIconSource.Glyph = "\xE896";
                 }
-                else if (path == App.AppSettings.DocumentsPath)
+                else if (path.StartsWith(App.AppSettings.DocumentsPath, StringComparison.OrdinalIgnoreCase))
                 {
                     tabLocationHeader = resourceLoader.GetString("SidebarDocuments");
                     fontIconSource.Glyph = "\xE8A5";
                 }
-                else if (path == App.AppSettings.PicturesPath)
+                else if (path.StartsWith(App.AppSettings.PicturesPath, StringComparison.OrdinalIgnoreCase))
                 {
                     tabLocationHeader = resourceLoader.GetString("SidebarPictures");
                     fontIconSource.Glyph = "\xEB9F";
                 }
-                else if (path == App.AppSettings.MusicPath)
+                else if (path.StartsWith(App.AppSettings.MusicPath, StringComparison.OrdinalIgnoreCase))
                 {
                     tabLocationHeader = resourceLoader.GetString("SidebarMusic");
                     fontIconSource.Glyph = "\xEC4F";
                 }
-                else if (path == App.AppSettings.VideosPath)
+                else if (path.StartsWith(App.AppSettings.VideosPath, StringComparison.OrdinalIgnoreCase))
                 {
                     tabLocationHeader = resourceLoader.GetString("SidebarVideos");
                     fontIconSource.Glyph = "\xE8B2";
                 }
-                else if (path == App.AppSettings.OneDrivePath)
+                else if (App.AppSettings.OneDrivePath != null && path.StartsWith(App.AppSettings.OneDrivePath, StringComparison.OrdinalIgnoreCase))
                 {
                     tabLocationHeader = "OneDrive";
                     fontIconSource.Glyph = "\xE753";
@@ -222,37 +222,37 @@ namespace Files
                 tabLocationHeader = "New tab";
                 fontIconSource.Glyph = "\xE737";
             }
-            else if (currentPathForTabIcon == App.AppSettings.DesktopPath)
+            else if (currentPathForTabIcon.StartsWith(App.AppSettings.DesktopPath, StringComparison.OrdinalIgnoreCase))
             {
                 tabLocationHeader = resourceLoader.GetString("SidebarDesktop");
                 fontIconSource.Glyph = "\xE8FC";
             }
-            else if (currentPathForTabIcon == App.AppSettings.DownloadsPath)
+            else if (currentPathForTabIcon.StartsWith(App.AppSettings.DownloadsPath, StringComparison.OrdinalIgnoreCase))
             {
                 tabLocationHeader = resourceLoader.GetString("SidebarDownloads");
                 fontIconSource.Glyph = "\xE896";
             }
-            else if (currentPathForTabIcon == App.AppSettings.DocumentsPath)
+            else if (currentPathForTabIcon.StartsWith(App.AppSettings.DocumentsPath, StringComparison.OrdinalIgnoreCase))
             {
                 tabLocationHeader = resourceLoader.GetString("SidebarDocuments");
                 fontIconSource.Glyph = "\xE8A5";
             }
-            else if (currentPathForTabIcon == App.AppSettings.PicturesPath)
+            else if (currentPathForTabIcon.StartsWith(App.AppSettings.PicturesPath, StringComparison.OrdinalIgnoreCase))
             {
                 tabLocationHeader = resourceLoader.GetString("SidebarPictures");
                 fontIconSource.Glyph = "\xEB9F";
             }
-            else if (currentPathForTabIcon == App.AppSettings.MusicPath)
+            else if (currentPathForTabIcon.StartsWith(App.AppSettings.MusicPath, StringComparison.OrdinalIgnoreCase))
             {
                 tabLocationHeader = resourceLoader.GetString("SidebarMusic");
                 fontIconSource.Glyph = "\xEC4F";
             }
-            else if (currentPathForTabIcon == App.AppSettings.VideosPath)
+            else if (currentPathForTabIcon.StartsWith(App.AppSettings.VideosPath, StringComparison.OrdinalIgnoreCase))
             {
                 tabLocationHeader = resourceLoader.GetString("SidebarVideos");
                 fontIconSource.Glyph = "\xE8B2";
             }
-            else if (currentPathForTabIcon == App.AppSettings.OneDrivePath)
+            else if (App.AppSettings.OneDrivePath != null && currentPathForTabIcon.StartsWith(App.AppSettings.OneDrivePath, StringComparison.OrdinalIgnoreCase))
             {
                 tabLocationHeader = "OneDrive";
                 fontIconSource.Glyph = "\xE753";


### PR DESCRIPTION
Compares the start of the folder path with the special folder paths, instead of a direct comparison. This allows for nested folders to be recognized as part of the "special folders" as well.

Also fixes a spelling error "Naviagtion" and removes extraneous assignment of `SidebarSelectedItem` which is already done in the `set` function of `WorkingDirectory`.

![image](https://user-images.githubusercontent.com/8487294/79052156-18eecb80-7c67-11ea-8947-d4c0a02fcd01.png)


Resolves #525