### PR TITLE
Focus on items after they are pasted

### DIFF
--- a/Files/BaseLayout.cs
+++ b/Files/BaseLayout.cs
@@ -73,6 +73,7 @@ namespace Files
                     {
                         IsItemSelected = true;
                     }
+                    SetSelectedItemsOnUi(value);
                     NotifyPropertyChanged("SelectedItems");
                 }
             }
@@ -98,6 +99,7 @@ namespace Files
                     {
                         IsItemSelected = true;
                     }
+                    SetSelectedItemOnUi(value);
                     NotifyPropertyChanged("SelectedItem");
                 }
             }
@@ -118,6 +120,10 @@ namespace Files
                 IsQuickLookEnabled = true;
             }
         }
+
+        protected abstract void SetSelectedItemOnUi(ListedItem selectedItem);
+
+        protected abstract void SetSelectedItemsOnUi(List<ListedItem> selectedItems);
 
         private void AppSettings_LayoutModeChangeRequested(object sender, EventArgs e)
         {
@@ -144,7 +150,7 @@ namespace Files
             PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
         }
 
-        protected override void OnNavigatedTo(NavigationEventArgs eventArgs)
+        protected override async void OnNavigatedTo(NavigationEventArgs eventArgs)
         {
             base.OnNavigatedTo(eventArgs);
             // Add item jumping handler
@@ -171,9 +177,9 @@ namespace Files
                 App.CurrentInstance.NavigationToolbar.CanNavigateToParent = true;
             }
 
-            App.CurrentInstance.ViewModel.AddItemsToCollectionAsync(App.CurrentInstance.ViewModel.WorkingDirectory);
-            App.Clipboard_ContentChanged(null, null);
+            await App.CurrentInstance.ViewModel.RefreshItems();
 
+            App.Clipboard_ContentChanged(null, null);
             App.CurrentInstance.NavigationToolbar.PathControlDisplayText = parameters;
         }
 

--- a/Files/Interacts/Interaction.cs
+++ b/Files/Interacts/Interaction.cs
@@ -843,7 +843,7 @@ namespace Files.Interacts
             Clipboard.Flush();
         }
         public string CopySourcePath;
-        public IReadOnlyList<IStorageItem> ItemsToPaste;
+        public IReadOnlyList<IStorageItem> itemsToPaste;
         public int itemsPasted;
 
         public async void CopyItem_ClickAsync(object sender, RoutedEventArgs e)
@@ -908,31 +908,36 @@ namespace Files.Interacts
 
         public async void PasteItem_ClickAsync(object sender, RoutedEventArgs e)
         {
-            string DestinationPath = CurrentInstance.ViewModel.WorkingDirectory;
+            string destinationPath = CurrentInstance.ViewModel.WorkingDirectory;
 
             DataPackageView packageView = Clipboard.GetContent();
-            ItemsToPaste = await packageView.GetStorageItemsAsync();
+            itemsToPaste = await packageView.GetStorageItemsAsync();
+            HashSet<string> pastedItemPaths = new HashSet<string>();
             itemsPasted = 0;
-            if (ItemsToPaste.Count > 3)
+            if (itemsToPaste.Count > 3)
             {
-                (App.CurrentInstance as ModernShellPage).UpdateProgressFlyout(InteractionOperationType.PasteItems, itemsPasted, ItemsToPaste.Count);
+                (App.CurrentInstance as ModernShellPage).UpdateProgressFlyout(InteractionOperationType.PasteItems, itemsPasted, itemsToPaste.Count);
             }
 
-            foreach (IStorageItem item in ItemsToPaste)
+            foreach (IStorageItem item in itemsToPaste)
             {
 
                 if (item.IsOfType(StorageItemTypes.Folder))
                 {
-                    await CloneDirectoryAsync(item.Path, DestinationPath, item.Name, false);
+                    StorageFolder pastedFolder = await CloneDirectoryAsync(item.Path, destinationPath, item.Name, false);
+                    CurrentInstance.ViewModel.AddFolder(pastedFolder.Path);
+                    pastedItemPaths.Add(pastedFolder.Path);
                 }
                 else if (item.IsOfType(StorageItemTypes.File))
                 {
-                    if (ItemsToPaste.Count > 3)
+                    if (itemsToPaste.Count > 3)
                     {
-                        (App.CurrentInstance as ModernShellPage).UpdateProgressFlyout(InteractionOperationType.PasteItems, ++itemsPasted, ItemsToPaste.Count);
+                        (App.CurrentInstance as ModernShellPage).UpdateProgressFlyout(InteractionOperationType.PasteItems, ++itemsPasted, itemsToPaste.Count);
                     }
-                    StorageFile ClipboardFile = await StorageFile.GetFileFromPathAsync(item.Path);
-                    await ClipboardFile.CopyAsync(await StorageFolder.GetFolderFromPathAsync(DestinationPath), item.Name, NameCollisionOption.GenerateUniqueName);
+                    StorageFile clipboardFile = await StorageFile.GetFileFromPathAsync(item.Path);
+                    StorageFile pastedFile = await clipboardFile.CopyAsync(await StorageFolder.GetFolderFromPathAsync(destinationPath), item.Name, NameCollisionOption.GenerateUniqueName);
+                    pastedItemPaths.Add(pastedFile.Path);
+                    CurrentInstance.ViewModel.AddFile(pastedFile.Path);
                 }
             }
 
@@ -952,10 +957,11 @@ namespace Files.Interacts
                     }
                 }
             }
-
+            List<ListedItem> copiedItems = CurrentInstance.ViewModel.FilesAndFolders.Where(listedItem => pastedItemPaths.Contains(listedItem.ItemPath)).ToList();
+            CurrentInstance.ContentPage.SelectedItems = copiedItems;
         }
 
-        public async Task CloneDirectoryAsync(string SourcePath, string DestinationPath, string sourceRootName, bool suppressProgressFlyout)
+        public async Task<StorageFolder> CloneDirectoryAsync(string SourcePath, string DestinationPath, string sourceRootName, bool suppressProgressFlyout)
         {
             StorageFolder SourceFolder = await StorageFolder.GetFolderFromPathAsync(SourcePath);
             StorageFolder DestinationFolder = await StorageFolder.GetFolderFromPathAsync(DestinationPath);
@@ -964,11 +970,11 @@ namespace Files.Interacts
 
             foreach (StorageFile fileInSourceDir in await SourceFolder.GetFilesAsync())
             {
-                if(ItemsToPaste != null)
+                if(itemsToPaste != null)
                 {
-                    if (ItemsToPaste.Count > 3 && !suppressProgressFlyout)
+                    if (itemsToPaste.Count > 3 && !suppressProgressFlyout)
                     {
-                        (App.CurrentInstance as ModernShellPage).UpdateProgressFlyout(InteractionOperationType.PasteItems, ++itemsPasted, ItemsToPaste.Count + (await SourceFolder.GetItemsAsync()).Count);
+                        (App.CurrentInstance as ModernShellPage).UpdateProgressFlyout(InteractionOperationType.PasteItems, ++itemsPasted, itemsToPaste.Count + (await SourceFolder.GetItemsAsync()).Count);
                     }
                 }
 
@@ -976,17 +982,17 @@ namespace Files.Interacts
             }
             foreach (StorageFolder folderinSourceDir in await SourceFolder.GetFoldersAsync())
             {
-                if (ItemsToPaste != null)
+                if (itemsToPaste != null)
                 {
-                    if (ItemsToPaste.Count > 3 && !suppressProgressFlyout)
+                    if (itemsToPaste.Count > 3 && !suppressProgressFlyout)
                     {
-                        (App.CurrentInstance as ModernShellPage).UpdateProgressFlyout(InteractionOperationType.PasteItems, ++itemsPasted, ItemsToPaste.Count + (await SourceFolder.GetItemsAsync()).Count);
+                        (App.CurrentInstance as ModernShellPage).UpdateProgressFlyout(InteractionOperationType.PasteItems, ++itemsPasted, itemsToPaste.Count + (await SourceFolder.GetItemsAsync()).Count);
                     }
                 }
 
                 await CloneDirectoryAsync(folderinSourceDir.Path, DestinationFolder.Path, folderinSourceDir.Name, false);
             }
-
+            return createdRoot;
         }
 
         public void NewFolder_Click(object sender, RoutedEventArgs e)

--- a/Files/Navigation/NavigationActions.cs
+++ b/Files/Navigation/NavigationActions.cs
@@ -11,10 +11,10 @@ namespace Files
     {
         public async static void Refresh_Click(object sender, RoutedEventArgs e)
         {
-            await Windows.ApplicationModel.Core.CoreApplication.MainView.CoreWindow.Dispatcher.RunAsync(CoreDispatcherPriority.Normal, () =>
+            await Windows.ApplicationModel.Core.CoreApplication.MainView.CoreWindow.Dispatcher.RunAsync(CoreDispatcherPriority.Normal, async () =>
             {
                 var ContentOwnedViewModelInstance = App.CurrentInstance.ViewModel;
-                ContentOwnedViewModelInstance.AddItemsToCollectionAsync(ContentOwnedViewModelInstance.WorkingDirectory);
+                await ContentOwnedViewModelInstance.RefreshItems();
             });
         }
 

--- a/Files/UserControls/LayoutModes/PhotoAlbum.xaml.cs
+++ b/Files/UserControls/LayoutModes/PhotoAlbum.xaml.cs
@@ -1,5 +1,6 @@
 ﻿using Files.Filesystem;
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using Windows.System;
 using Windows.UI.Core;
@@ -18,6 +19,29 @@ namespace Files
         {
             this.InitializeComponent();
 
+        }
+        protected override void SetSelectedItemOnUi(ListedItem selectedItem)
+        {
+            // Required to check if sequences are equal, if not it will result in an infinite loop
+            // between the UI Control and the BaseLayout set function
+            if (FileList.SelectedItem != selectedItem)
+            {
+                FileList.SelectedItem = selectedItem;
+                FileList.UpdateLayout();
+                FileList.ScrollIntoView(FileList.SelectedItem);
+            }
+        }
+        protected override void SetSelectedItemsOnUi(List<ListedItem> selectedItems)
+        {
+            // Required to check if sequences are equal, if not it will result in an infinite loop
+            // between the UI Control and the BaseLayout set function
+            if (Enumerable.SequenceEqual<ListedItem>(FileList.SelectedItems.Cast<ListedItem>(), selectedItems))
+                return;
+            FileList.SelectedItems.Clear();
+            foreach (ListedItem selectedItem in selectedItems)
+                FileList.SelectedItems.Add(selectedItem);
+            FileList.UpdateLayout();
+            FileList.ScrollIntoView(FileList.Items.Last());
         }
 
         private void StackPanel_RightTapped(object sender, RightTappedRoutedEventArgs e)

--- a/Files/View Models/ItemViewModel.cs
+++ b/Files/View Models/ItemViewModel.cs
@@ -614,7 +614,12 @@ namespace Files.Filesystem
             }
         }
 
-        public async void RapidAddItemsToCollectionAsync(string path)
+        public async Task RefreshItems()
+        {
+            await AddItemsToCollectionAsync(WorkingDirectory);
+        }
+
+        public async Task RapidAddItemsToCollectionAsync(string path)
         {
             App.CurrentInstance.NavigationToolbar.CanRefresh = false;
 
@@ -752,6 +757,16 @@ namespace Files.Filesystem
             IsLoadingItems = false;
         }
 
+        public void AddFolder(string folderPath)
+        {
+            FINDEX_INFO_LEVELS findInfoLevel = FINDEX_INFO_LEVELS.FindExInfoBasic;
+            int additionalFlags = FIND_FIRST_EX_CASE_SENSITIVE;
+
+            IntPtr hFile = FindFirstFileExFromApp(folderPath, findInfoLevel, out WIN32_FIND_DATA findData, FINDEX_SEARCH_OPS.FindExSearchNameMatch, IntPtr.Zero,
+                                                  additionalFlags);
+            AddFolder(findData, Directory.GetParent(folderPath).FullName);
+        }
+
         private void AddFolder(WIN32_FIND_DATA findData, string pathRoot)
         {
             if ((App.CurrentInstance.CurrentPageType) == typeof(GenericFileBrowser) || (App.CurrentInstance.CurrentPageType == typeof(PhotoAlbum)))
@@ -792,6 +807,16 @@ namespace Files.Filesystem
 
                 EmptyTextState.IsVisible = Visibility.Collapsed;
             }
+        }
+
+        public void AddFile(string filePath)
+        {
+            FINDEX_INFO_LEVELS findInfoLevel = FINDEX_INFO_LEVELS.FindExInfoBasic;
+            int additionalFlags = FIND_FIRST_EX_CASE_SENSITIVE;
+
+            IntPtr hFile = FindFirstFileExFromApp(filePath, findInfoLevel, out WIN32_FIND_DATA findData, FINDEX_SEARCH_OPS.FindExSearchNameMatch, IntPtr.Zero,
+                                                  additionalFlags);
+            AddFile(findData, Directory.GetParent(filePath).FullName);
         }
 
         private void AddFile(WIN32_FIND_DATA findData, string pathRoot)
@@ -858,9 +883,9 @@ namespace Files.Filesystem
             EmptyTextState.IsVisible = Visibility.Collapsed;
         }
 
-        public void AddItemsToCollectionAsync(string path)
+        public async Task AddItemsToCollectionAsync(string path)
         {
-            RapidAddItemsToCollectionAsync(path);
+            await RapidAddItemsToCollectionAsync(path);
             return;
         }
 
@@ -891,7 +916,6 @@ namespace Files.Filesystem
                 //}
 
                 //string tooltipString = dateCreatedText + "\n" + "Folders: " + firstFoldersText + "\n" + "Files: " + firstFilesText;
-
                 _filesAndFolders.Add(new ListedItem(folder.FolderRelativeId)
                 {
                     //FolderTooltipText = tooltipString,


### PR DESCRIPTION
The app now refreshes when items are pasted (it wasn't doing so for me), and focuses on the pasted items.

### Before paste
![image](https://user-images.githubusercontent.com/8487294/79065411-b1766180-7ce2-11ea-84f0-6df7e630c29f.png)
![image](https://user-images.githubusercontent.com/8487294/79065464-074b0980-7ce3-11ea-9810-3c7f95f4cbf9.png)


### After paste
![image](https://user-images.githubusercontent.com/8487294/79065415-b89d6f80-7ce2-11ea-88b8-477cda79aff1.png)
![image](https://user-images.githubusercontent.com/8487294/79065469-0dd98100-7ce3-11ea-88ca-be7531e629db.png)

Resolves #211.