### PR TITLE
Add Invert Selection, icons to status bar, fix folder navigation and remove space before .dll

### DIFF
--- a/Files/BaseLayout.cs
+++ b/Files/BaseLayout.cs
@@ -126,6 +126,8 @@ namespace Files
 
         protected abstract void SetSelectedItemsOnUi(List<ListedItem> selectedItems);
 
+        public abstract void FocusSelectedItems();
+        
         protected abstract ListedItem GetItemFromElement(object element);
 
         private void AppSettings_LayoutModeChangeRequested(object sender, EventArgs e)
@@ -321,6 +323,11 @@ namespace Files
                     selectedStorageItems.Add(await StorageFolder.GetFolderFromPathAsync(item.ItemPath));
             }
 
+            if (selectedStorageItems.Count == 0) {
+                e.Cancel = true;
+                return;
+            }
+
             e.Data.SetStorageItems(selectedStorageItems);
             e.DragUI.SetContentFromDataPackage();
         }
@@ -354,7 +361,7 @@ namespace Files
         protected void InitializeDrag(UIElement element)
         {
             ListedItem item = GetItemFromElement(element);
-            if(item != null)
+            if (item != null)
             {
                 element.AllowDrop = false;
                 element.DragStarting -= Item_DragStarting;

--- a/Files/Helpers/NaturalStringComparer.cs
+++ b/Files/Helpers/NaturalStringComparer.cs
@@ -21,7 +21,7 @@ namespace Files.Helpers
         public static readonly String LOCALE_NAME_INVARIANT = String.Empty;
         public static readonly String LOCALE_NAME_SYSTEM_DEFAULT = "!sys-default-locale";
 
-        [DllImport("api-ms-win-core-string-l1-1-0 .dll", CharSet = CharSet.Unicode)]
+        [DllImport("api-ms-win-core-string-l1-1-0.dll", CharSet = CharSet.Unicode)]
         public static extern Int32 CompareStringEx(
           String localeName,
           Int32 flags,

--- a/Files/Interacts/Interaction.cs
+++ b/Files/Interacts/Interaction.cs
@@ -943,7 +943,7 @@ namespace Files.Interacts
 
             if (acceptedOperation == DataPackageOperation.Move)
             {
-                foreach (IStorageItem item in itemsToPaste)
+                foreach (IStorageItem item in pastedItems)
                 {
                     if (item.IsOfType(StorageItemTypes.File))
                     {
@@ -965,6 +965,7 @@ namespace Files.Interacts
                 List<string> pastedItemPaths = pastedItems.Select(item => item.Path).ToList();
                 List<ListedItem> copiedItems = CurrentInstance.ViewModel.FilesAndFolders.Where(listedItem => pastedItemPaths.Contains(listedItem.ItemPath)).ToList();
                 CurrentInstance.ContentPage.SelectedItems = copiedItems;
+                CurrentInstance.ContentPage.FocusSelectedItems();
             }
             packageView.ReportOperationCompleted(acceptedOperation);
         }
@@ -1087,34 +1088,21 @@ namespace Files.Interacts
 
         public void SelectAllItems()
         {
-            if (App.CurrentInstance.CurrentPageType == typeof(GenericFileBrowser))
-            {
-                var CurrentInstance = App.CurrentInstance;
-                foreach (ListedItem li in (CurrentInstance.ContentPage as GenericFileBrowser).AllView.ItemsSource)
-                {
-                    if (!(CurrentInstance.ContentPage as GenericFileBrowser).SelectedItems.Contains(li))
-                    {
-                        (CurrentInstance.ContentPage as GenericFileBrowser).AllView.SelectedItems.Add(li);
-                    }
-                }
-            }
-            else if (App.CurrentInstance.CurrentPageType == typeof(PhotoAlbum))
-            {
-                (CurrentInstance.ContentPage as PhotoAlbum).FileList.SelectAll();
-            }
+            CurrentInstance.ContentPage.SelectedItems = App.CurrentInstance.ViewModel.FilesAndFolders.ToList();
+        }
+
+        public void InvertAllItems()
+        {
+            List<ListedItem> oldSelectedItems = CurrentInstance.ContentPage.SelectedItems;
+            List<ListedItem> newSelectedItems = CurrentInstance.ViewModel.FilesAndFolders.ToList();
+            foreach (ListedItem listedItem in oldSelectedItems)
+                newSelectedItems.Remove(listedItem);
+            CurrentInstance.ContentPage.SelectedItems = newSelectedItems;
         }
 
         public void ClearAllItems()
         {
-            if (App.CurrentInstance.CurrentPageType == typeof(GenericFileBrowser))
-            {
-                var CurrentInstance = App.CurrentInstance;
-                (CurrentInstance.ContentPage as GenericFileBrowser).AllView.SelectedItems.Clear();
-            }
-            else if (App.CurrentInstance.CurrentPageType == typeof(PhotoAlbum))
-            {
-                (CurrentInstance.ContentPage as PhotoAlbum).FileList.SelectedItems.Clear();
-            }
+            CurrentInstance.ContentPage.SelectedItems = new List<ListedItem>();
         }
 
         public void ToggleQuickLook_Click(object sender, RoutedEventArgs e)

--- a/Files/MultilingualResources/Files.de-DE.xlf
+++ b/Files/MultilingualResources/Files.de-DE.xlf
@@ -578,6 +578,10 @@
           <source>Settings</source>
           <target state="new">Settings</target>
         </trans-unit>
+        <trans-unit id="StatusBarControlInvertSelection.Text" translate="yes" xml:space="preserve">
+          <source>Invert Selection</source>
+          <target state="new">Invert Selection</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/Files/MultilingualResources/Files.es-ES.xlf
+++ b/Files/MultilingualResources/Files.es-ES.xlf
@@ -574,6 +574,10 @@
           <source>Settings</source>
           <target state="translated">Ajustes</target>
         </trans-unit>
+        <trans-unit id="StatusBarControlInvertSelection.Text" translate="yes" xml:space="preserve">
+          <source>Invert Selection</source>
+          <target state="new">Invert Selection</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/Files/MultilingualResources/Files.fr-FR.xlf
+++ b/Files/MultilingualResources/Files.fr-FR.xlf
@@ -576,6 +576,10 @@
           <source>Settings</source>
           <target state="new">Settings</target>
         </trans-unit>
+        <trans-unit id="StatusBarControlInvertSelection.Text" translate="yes" xml:space="preserve">
+          <source>Invert Selection</source>
+          <target state="new">Invert Selection</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/Files/MultilingualResources/Files.nl-NL.xlf
+++ b/Files/MultilingualResources/Files.nl-NL.xlf
@@ -576,6 +576,10 @@
           <source>Settings</source>
           <target state="new">Settings</target>
         </trans-unit>
+        <trans-unit id="StatusBarControlInvertSelection.Text" translate="yes" xml:space="preserve">
+          <source>Invert Selection</source>
+          <target state="new">Invert Selection</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/Files/MultilingualResources/Files.pl-PL.xlf
+++ b/Files/MultilingualResources/Files.pl-PL.xlf
@@ -576,6 +576,10 @@
           <source>Settings</source>
           <target state="new">Settings</target>
         </trans-unit>
+        <trans-unit id="StatusBarControlInvertSelection.Text" translate="yes" xml:space="preserve">
+          <source>Invert Selection</source>
+          <target state="new">Invert Selection</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/Files/MultilingualResources/Files.ru-RU.xlf
+++ b/Files/MultilingualResources/Files.ru-RU.xlf
@@ -577,6 +577,10 @@
           <source>Settings</source>
           <target state="new">Settings</target>
         </trans-unit>
+        <trans-unit id="StatusBarControlInvertSelection.Text" translate="yes" xml:space="preserve">
+          <source>Invert Selection</source>
+          <target state="new">Invert Selection</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/Files/MultilingualResources/Files.tr-TR.xlf
+++ b/Files/MultilingualResources/Files.tr-TR.xlf
@@ -576,6 +576,10 @@
           <source>Settings</source>
           <target state="new">Settings</target>
         </trans-unit>
+        <trans-unit id="StatusBarControlInvertSelection.Text" translate="yes" xml:space="preserve">
+          <source>Invert Selection</source>
+          <target state="new">Invert Selection</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/Files/MultilingualResources/Files.uk-UA.xlf
+++ b/Files/MultilingualResources/Files.uk-UA.xlf
@@ -577,6 +577,10 @@
           <source>Settings</source>
           <target state="new">Settings</target>
         </trans-unit>
+        <trans-unit id="StatusBarControlInvertSelection.Text" translate="yes" xml:space="preserve">
+          <source>Invert Selection</source>
+          <target state="new">Invert Selection</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/Files/MultilingualResources/Files.zh-Hans.xlf
+++ b/Files/MultilingualResources/Files.zh-Hans.xlf
@@ -576,6 +576,10 @@
           <source>Settings</source>
           <target state="new">Settings</target>
         </trans-unit>
+        <trans-unit id="StatusBarControlInvertSelection.Text" translate="yes" xml:space="preserve">
+          <source>Invert Selection</source>
+          <target state="new">Invert Selection</target>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/Files/Strings/en-US/Resources.resw
+++ b/Files/Strings/en-US/Resources.resw
@@ -155,7 +155,7 @@
   </data>
   <data name="ModernNavigationToolbaNewTextDocument.Text" xml:space="preserve">
     <value>Text Document</value>
-  </data> 
+  </data>
   <data name="NavigationToolbarCopyPath.Text" xml:space="preserve">
     <value>Copy Path</value>
   </data>
@@ -219,21 +219,24 @@
   <data name="StatusBarControlSelectAll.Text" xml:space="preserve">
     <value>Select All</value>
   </data>
+  <data name="StatusBarControlInvertSelection.Text" xml:space="preserve">
+    <value>Invert Selection</value>
+  </data>
   <data name="StatusBarControlClearSelection.Text" xml:space="preserve">
     <value>Clear Selection</value>
-  </data>  
+  </data>
   <data name="StatusBarControlListView.Text" xml:space="preserve">
     <value>List View</value>
   </data>
   <data name="StatusBarControlGridView.Text" xml:space="preserve">
     <value>Grid View</value>
-  </data>  
+  </data>
   <data name="PropertiesModified.Text" xml:space="preserve">
     <value>Modified:</value>
   </data>
   <data name="RecentItemClearAll.Text" xml:space="preserve">
     <value>Clear all items</value>
-  </data>  
+  </data>
   <data name="NavigationToolbarVisiblePath.PlaceholderText" xml:space="preserve">
     <value>Enter a path</value>
   </data>

--- a/Files/UserControls/LayoutModes/GenericFileBrowser.xaml.cs
+++ b/Files/UserControls/LayoutModes/GenericFileBrowser.xaml.cs
@@ -86,9 +86,9 @@ namespace Files
             {
                 AllView.SelectedItem = selectedItem;
                 AllView.UpdateLayout();
-                AllView.ScrollIntoView(AllView.SelectedItem, null);
             }
         }
+
         protected override void SetSelectedItemsOnUi(List<ListedItem> selectedItems)
         {
             // To prevent program from crashing when the page is first loaded
@@ -108,6 +108,10 @@ namespace Files
             foreach (ListedItem selectedItem in selectedItems)
                 AllView.SelectedItems.Add(selectedItem);
             AllView.UpdateLayout();
+        }
+
+        public override void FocusSelectedItems()
+        {
             AllView.ScrollIntoView(AllView.ItemsSource.Cast<ListedItem>().Last(), null);
         }
 

--- a/Files/UserControls/LayoutModes/PhotoAlbum.xaml.cs
+++ b/Files/UserControls/LayoutModes/PhotoAlbum.xaml.cs
@@ -29,7 +29,6 @@ namespace Files
             {
                 FileList.SelectedItem = selectedItem;
                 FileList.UpdateLayout();
-                FileList.ScrollIntoView(FileList.SelectedItem);
             }
         }
         protected override void SetSelectedItemsOnUi(List<ListedItem> selectedItems)
@@ -40,11 +39,10 @@ namespace Files
                 foreach (ListedItem listedItem in FileList.Items)
                 {
                     GridViewItem gridViewItem = FileList.ContainerFromItem(listedItem) as GridViewItem;
-                    
                     List<Grid> grids = new List<Grid>();
                     Interaction.FindChildren<Grid>(grids, gridViewItem);
-                    var imageOfItem = grids.Find(x => x.Tag?.ToString() == "ItemRoot");
-                    imageOfItem.CanDrag = selectedItems.Contains(listedItem);
+                    var rootItem = grids.Find(x => x.Tag?.ToString() == "ItemRoot");
+                    rootItem.CanDrag = selectedItems.Contains(listedItem);
                 }
             }
 
@@ -56,6 +54,10 @@ namespace Files
             foreach (ListedItem selectedItem in selectedItems)
                 FileList.SelectedItems.Add(selectedItem);
             FileList.UpdateLayout();
+        }
+
+        public override void FocusSelectedItems()
+        {
             FileList.ScrollIntoView(FileList.Items.Last());
         }
 

--- a/Files/UserControls/StatusBarControl.xaml
+++ b/Files/UserControls/StatusBarControl.xaml
@@ -37,10 +37,20 @@
                     <MenuFlyout>
                         <MenuFlyoutItem
                             x:Uid="StatusBarControlSelectAll"
+                            Icon="SelectAll"
                             Click="{x:Bind local1:App.CurrentInstance.InteractionOperations.SelectAllItems}"
                             Text="Select All" />
                         <MenuFlyoutItem
+                            x:Uid="StatusBarControlInvertSelection"
+                            Click="{x:Bind local1:App.CurrentInstance.InteractionOperations.InvertAllItems}"
+                            Text="Invert Selection">
+                            <MenuFlyoutItem.Icon>
+                                <FontIcon FontFamily="Segoe MDL2 Assets" Glyph="&#xE746;"/>
+                            </MenuFlyoutItem.Icon>
+                        </MenuFlyoutItem>
+                        <MenuFlyoutItem
                             x:Uid="StatusBarControlClearSelection"
+                            Icon="ClearSelection"
                             Click="{x:Bind local1:App.CurrentInstance.InteractionOperations.ClearAllItems}"
                             Text="Clear Selection" />
                     </MenuFlyout>


### PR DESCRIPTION
Resolves #601.
Resolves #274.

Previously, when the user navigates into the folder using double click, sometimes it may register as a drag. The program then tries to take the selected files and put it into a `DataPackage` to start the drag process. But when there are no selected files, the `DataPackage` throws an error.

This commit adds a check to see if the selected items list is empty. If it is, cancel the drag gesture.

There's also a bug that causes a folder to delete itself, when it is dragged into itself and "skip" is pressed on the dialog that comes afterwards.

Also adds an Invert Selection and some icons to the menu in the status bar.
![image](https://user-images.githubusercontent.com/8487294/79346080-80a55f00-7f64-11ea-9bf5-75c89441118a.png)
