### PR TITLE
Fix properties window crash

### DIFF
--- a/Files/Views/Pages/Properties.xaml
+++ b/Files/Views/Pages/Properties.xaml
@@ -157,6 +157,13 @@
                     IsTextSelectionEnabled="True"
                     Text="{x:Bind ItemProperties.ItemMD5Hash, Mode=OneWay}"
                     Visibility="{x:Bind ItemProperties.ItemMD5HashVisibility, Mode=OneWay}" />
+                <ProgressBar
+                    x:Name="ItemMD5HashProgress"
+                    Grid.Row="5"
+                    Grid.Column="1"
+                    Margin="20,0,0,0"
+                    IsIndeterminate="True"
+                    Visibility="{x:Bind ItemProperties.ItemMD5HashProgressVisibility, Mode=OneWay}" />
 
                 <MenuFlyoutSeparator
                     Grid.Row="6"

--- a/Files/Views/Pages/Properties.xaml.cs
+++ b/Files/Views/Pages/Properties.xaml.cs
@@ -54,18 +54,10 @@ namespace Files
                 if (selectedItem.PrimaryItemAttribute == StorageItemTypes.File)
                 {
                     selectedStorageItem = await StorageFile.GetFileFromPathAsync(selectedItem.ItemPath);
-                    var hashAlgTypeName = HashAlgorithmNames.Md5;
-
-                    // get file hash
-                    ItemProperties.ItemMD5Hash = await App.CurrentInstance.InteractionOperations.GetHashForFile(selectedItem, hashAlgTypeName);
-
-                    ItemProperties.ItemMD5HashVisibility = Visibility.Visible;
                 }
                 else if (selectedItem.PrimaryItemAttribute == StorageItemTypes.Folder)
                 {
                     selectedStorageItem = await StorageFolder.GetFolderFromPathAsync(selectedItem.ItemPath);
-
-                    ItemProperties.ItemMD5HashVisibility = Visibility.Collapsed;
                 }
 
                 ItemProperties.ItemName = selectedItem.ItemName;
@@ -84,6 +76,21 @@ namespace Files
                     var bitmap = new BitmapImage();
                     await bitmap.SetSourceAsync(thumbnail);
                     ItemProperties.FileIconSource = bitmap;
+                }
+
+                if (selectedItem.PrimaryItemAttribute == StorageItemTypes.File)
+                {
+                    // get file MD5 hash
+                    var hashAlgTypeName = HashAlgorithmNames.Md5;
+                    ItemProperties.ItemMD5HashProgressVisibility = Visibility.Visible;
+                    ItemProperties.ItemMD5Hash = await App.CurrentInstance.InteractionOperations.GetHashForFile(selectedItem, hashAlgTypeName);
+                    ItemProperties.ItemMD5HashProgressVisibility = Visibility.Collapsed;
+                    ItemProperties.ItemMD5HashVisibility = Visibility.Visible;
+                }
+                else if (selectedItem.PrimaryItemAttribute == StorageItemTypes.Folder)
+                {
+                    ItemProperties.ItemMD5HashVisibility = Visibility.Collapsed;
+                    ItemProperties.ItemMD5HashProgressVisibility = Visibility.Collapsed;
                 }
             }
             else
@@ -141,6 +148,7 @@ namespace Files
         private string _ItemPath;
         private string _ItemMD5Hash;
         private Visibility _ItemMD5HashVisibility;
+        private Visibility _ItemMD5HashProgressVisibiity;
         private string _ItemSize;
         private string _ItemCreatedTimestamp;
         private string _ItemModifiedTimestamp;
@@ -165,6 +173,12 @@ namespace Files
         {
             get => _ItemMD5HashVisibility;
             set => Set(ref _ItemMD5HashVisibility, value);
+        }
+
+        public Visibility ItemMD5HashProgressVisibility
+        {
+            get => _ItemMD5HashProgressVisibiity;
+            set => Set(ref _ItemMD5HashProgressVisibiity, value);
         }
 
         public string ItemType


### PR DESCRIPTION
Crash caused by MD5 hash algorithm calculation, it did not support large files.
Now file properties are shown before MD5 calculation. Added indeterminate progress bar.
Fixes #704 