### PR TITLE
Fix null detection of file extension

### DIFF
--- a/Files/View Models/InteractionViewModel.cs
+++ b/Files/View Models/InteractionViewModel.cs
@@ -48,27 +48,23 @@ namespace Files.Controls
 
         public void CheckForImage()
         {
-            //check if the selected item is an image file
-            try
-            {
-                string ItemExtension = (App.CurrentInstance.ContentPage as BaseLayout).SelectedItem.FileExtension;
+            string ItemExtension = (App.CurrentInstance.ContentPage as BaseLayout).SelectedItem.FileExtension;
 
-                if (!string.IsNullOrEmpty(ItemExtension)
-                    && ItemExtension.Equals(".png", StringComparison.OrdinalIgnoreCase)
-                    || ItemExtension.Equals(".jpg", StringComparison.OrdinalIgnoreCase)
-                    || ItemExtension.Equals(".bmp", StringComparison.OrdinalIgnoreCase)
-                    || ItemExtension.Equals(".jpeg", StringComparison.OrdinalIgnoreCase))
+            if (!string.IsNullOrEmpty(ItemExtension))
+            {
+                if (ItemExtension.Equals(".png", StringComparison.OrdinalIgnoreCase)
+                || ItemExtension.Equals(".jpg", StringComparison.OrdinalIgnoreCase)
+                || ItemExtension.Equals(".bmp", StringComparison.OrdinalIgnoreCase)
+                || ItemExtension.Equals(".jpeg", StringComparison.OrdinalIgnoreCase))
                 {
                     // Since item is an image, set the IsSelectedItemImage property to true
                     App.InteractionViewModel.IsSelectedItemImage = true;
-                }
-                else
-                {
-                    // Since item is not an image, set the IsSelectedItemImage property to false
-                    App.InteractionViewModel.IsSelectedItemImage = false;
+                    return;
                 }
             }
-            catch (Exception) { }
+
+            // Since item is not an image, folder or file without extension, set the IsSelectedItemImage property to false
+            App.InteractionViewModel.IsSelectedItemImage = false;
         }
     }
 }

--- a/Files/View Models/InteractionViewModel.cs
+++ b/Files/View Models/InteractionViewModel.cs
@@ -48,6 +48,7 @@ namespace Files.Controls
 
         public void CheckForImage()
         {
+            //check if the selected item is an image file
             string ItemExtension = (App.CurrentInstance.ContentPage as BaseLayout).SelectedItem.FileExtension;
 
             if (!string.IsNullOrEmpty(ItemExtension))


### PR DESCRIPTION
Remove try-catch block
The problem has not been solved in PR #770 because of try-catch block which is "handle" exception caused app not crashed if `ItemExtension==null`.