### PR TITLE
Fixed file rename with space added opening QuickLook

### DIFF
--- a/Files/Interacts/Interaction.cs
+++ b/Files/Interacts/Interaction.cs
@@ -1148,16 +1148,11 @@ namespace Files.Interacts
         {
             try
             {
-                string selectedItemPath = null;
                 int selectedItemCount;
                 Type sourcePageType = App.CurrentInstance.CurrentPageType;
                 selectedItemCount = (CurrentInstance.ContentPage as BaseLayout).SelectedItems.Count;
-                if (selectedItemCount == 1)
-                {
-                    selectedItemPath = (CurrentInstance.ContentPage as BaseLayout).SelectedItems[0].ItemPath;
-                }
 
-                if (selectedItemCount == 1)
+                if (selectedItemCount == 1 && !App.CurrentInstance.ContentPage.isRenamingItem)
                 {
                     var clickedOnItem = (CurrentInstance.ContentPage as BaseLayout).SelectedItems[0];
 


### PR DESCRIPTION
Fixed a bug that caused QuickLook to open when pressing spacebar while renaming a file.

Before:
![before](https://user-images.githubusercontent.com/46000533/81809850-48bd1780-9522-11ea-9c61-1d34836f4214.gif)
After:
![after](https://user-images.githubusercontent.com/46000533/81809874-507cbc00-9522-11ea-8ad8-d8f60adc289b.gif)

**To Reproduce In Current Version**
Steps to reproduce the behavior:
1. Make sure you have QuickLook installed.
2. Right click on a file and choose "Rename"
3. Give the file any name with a space in it. As soon as spacebar is pressed, QuickLook opens, the file name textbox loses focus and the file name is committed without allowing the user to finish typing.
