### PR TITLE
Added support for ctrl + click deselection in grid view.

### DIFF
--- a/Files/UserControls/LayoutModes/PhotoAlbum.xaml
+++ b/Files/UserControls/LayoutModes/PhotoAlbum.xaml
@@ -333,6 +333,7 @@
                         DataContext="{x:Bind}"
                         DataContextChanged="FileListGridItem_DataContextChanged"
                         EffectiveViewportChanged="Grid_EffectiveViewportChanged"
+                        PointerPressed="FileListGridItem_PointerPressed"
                         IsRightTapEnabled="True"
                         RightTapped="StackPanel_RightTapped"
                         Tag="ItemRoot"

--- a/Files/UserControls/LayoutModes/PhotoAlbum.xaml.cs
+++ b/Files/UserControls/LayoutModes/PhotoAlbum.xaml.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Windows.Devices.Input;
 using Windows.System;
 using Windows.UI.Core;
 using Windows.UI.Xaml;
@@ -210,6 +211,28 @@ namespace Files
         private void FileListGridItem_DataContextChanged(object sender, DataContextChangedEventArgs e)
         {
             InitializeDrag(sender as UIElement);
+        }
+
+        private void FileListGridItem_PointerPressed(object sender, PointerRoutedEventArgs e)
+        {
+            if (e.KeyModifiers == VirtualKeyModifiers.Control)
+            {
+                var listedItem = (sender as Grid).DataContext as ListedItem;
+                if (FileList.SelectedItems.Contains(listedItem))
+                {
+                    FileList.SelectedItems.Remove(listedItem);
+                    // Prevent issues arising caused by the default handlers attempting to select the item that has just been deselected by ctrl + click
+                    e.Handled = true;
+                }
+            }
+            else if (e.GetCurrentPoint(sender as UIElement).Properties.IsLeftButtonPressed)
+            {
+                var listedItem = (sender as Grid).DataContext as ListedItem;
+
+                FileList.SelectedItems.Clear(); // Control not clicked, clear selected items
+                FileList.SelectedItems.Add(listedItem);
+                FileList.SelectedItem = listedItem;
+            }
         }
     }
 }


### PR DESCRIPTION
Added support for ctrl + click deselection. (#752)

Also changed the behavior of a left click without ctrl to match that of the list view i.e. If you have a few selected items and click one of them without holding ctrl, then that item is selected and the others are deselected. (The end of the below gif is an example of this)

Here's a demo:
![GridViewDeselect](https://user-images.githubusercontent.com/46000533/82084434-95078380-96eb-11ea-929a-a65ca8188ed6.gif)
