### PR TITLE
Fix tab background color in dark mode when pointer over

### DIFF
--- a/Files/App.xaml
+++ b/Files/App.xaml
@@ -27,7 +27,7 @@
                             <SolidColorBrush x:Key="YourHomeCardBorderColor" Color="White" />
                             <SolidColorBrush x:Key="TabViewBackground" Color="Black" />
                             <SolidColorBrush x:Key="TabViewItemHeaderBackgroundSelected" Color="#191919" />
-                            <SolidColorBrush x:Key="TabViewItemHeaderBackgroundPointerOver" Color="#191919" />
+                            <SolidColorBrush x:Key="TabViewItemHeaderBackgroundPointerOver" Color="#80191919" />
                             <SolidColorBrush x:Key="TabViewItemHeaderBackgroundPressed" Color="#191919" />
                             <SolidColorBrush x:Key="CustomInputFieldBorderBrush" Color="#FF363636" />
                             <SolidColorBrush x:Key="RibbonBackgroundColor" Color="#131313" />


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/20501502/82596014-48bab880-9baf-11ea-9fcb-4ee96dca4338.png)
After:
![image](https://user-images.githubusercontent.com/20501502/82596057-5b34f200-9baf-11ea-8645-04323aaa1003.png)
Now it is easier to differ what tab is selected, what tab is in pointer over state and unselected tab