### PR TITLE
Fix files last modified date

### DIFF
--- a/Files/View Models/ItemViewModel.cs
+++ b/Files/View Models/ItemViewModel.cs
@@ -852,7 +852,8 @@ namespace Files.Filesystem
                     systemTimeOutput.Hour,
                     systemTimeOutput.Minute,
                     systemTimeOutput.Second,
-                    systemTimeOutput.Milliseconds);
+                    systemTimeOutput.Milliseconds,
+                    DateTimeKind.Utc);
                 var itemPath = Path.Combine(pathRoot, findData.cFileName);
                 //var resourceLoader = Windows.ApplicationModel.Resources.ResourceLoader.GetForViewIndependentUse();
                 //var typeText = resourceLoader.GetString("Folder");
@@ -905,7 +906,8 @@ namespace Files.Filesystem
                 systemTimeOutput.Hour,
                 systemTimeOutput.Minute,
                 systemTimeOutput.Second,
-                systemTimeOutput.Milliseconds);
+                systemTimeOutput.Milliseconds,
+                DateTimeKind.Utc);
             long fDataFSize = findData.nFileSizeLow;
             long fileSize;
             if (fDataFSize < 0 && findData.nFileSizeHigh > 0)


### PR DESCRIPTION
**Issue**
Currently Files UWP does not display files last modified date correctly: on my system where the timezone is UTC+2 a newly created file shows "Modified: 2 hours ago" (both in properties dialog and in "Date modified" column).
This pull request fixes this so it shows "Modified: 0 seconds ago".

**Fix**
The issue is due to the fact that the [`FileTimeToSystemTime`](https://docs.microsoft.com/en-us/windows/win32/api/timezoneapi/nf-timezoneapi-filetimetosystemtime) function returns an UTC time, but then a new DateTime object is constructed from the returned value without specifying the DateTimeKind as UTC.
```cs
var itemDate = new DateTime(
                systemTimeOutput.Year,
                systemTimeOutput.Month,
                systemTimeOutput.Day,
                systemTimeOutput.Hour,
                systemTimeOutput.Minute,
                systemTimeOutput.Second,
                systemTimeOutput.Milliseconds,
                DateTimeKind.Utc); -----------------> this is needed
```